### PR TITLE
Handle missing PrimaryElement in ore status converters

### DIFF
--- a/src/BetterInfoCards/Converters/StatusConverters.cs
+++ b/src/BetterInfoCards/Converters/StatusConverters.cs
@@ -16,15 +16,49 @@ namespace BetterInfoCards.Converters
             // ORE MASS
             ConverterManager.AddConverter(
                 oreMass.Id,
-                data => ((GameObject)data).GetComponent<PrimaryElement>().Mass,
+                data =>
+                {
+                    var go = (GameObject)data;
+                    var primaryElement = go.GetComponent<PrimaryElement>();
+                    if (primaryElement == null)
+                    {
+                        LogMissingPrimaryElementOnce(ref hasLoggedMissingPrimaryElementForMass, go, oreMass.Id);
+                        return 0f;
+                    }
+
+                    return primaryElement.Mass;
+                },
                 (original, masses) => oreMass.Name.Replace("{Mass}", GameUtil.GetFormattedMass(masses.Sum())) + ConverterManager.sumSuffix);
 
             // ORE TEMP
             ConverterManager.AddConverter(
                 oreTemp.Id,
-                data => ((GameObject)data).GetComponent<PrimaryElement>().Temperature,
+                data =>
+                {
+                    var go = (GameObject)data;
+                    var primaryElement = go.GetComponent<PrimaryElement>();
+                    if (primaryElement == null)
+                    {
+                        LogMissingPrimaryElementOnce(ref hasLoggedMissingPrimaryElementForTemp, go, oreTemp.Id);
+                        return 0f;
+                    }
+
+                    return primaryElement.Temperature;
+                },
                 (original, temps) => oreTemp.Name.Replace("{Temp}", GameUtil.GetFormattedTemperature(temps.Average())) + ConverterManager.avgSuffix,
                 new() { (x => x, Options.Opts.TemperatureBandWidth) });
+        }
+
+        private static bool hasLoggedMissingPrimaryElementForMass;
+        private static bool hasLoggedMissingPrimaryElementForTemp;
+
+        private static void LogMissingPrimaryElementOnce(ref bool hasLogged, GameObject go, string converterId)
+        {
+            if (hasLogged)
+                return;
+
+            hasLogged = true;
+            Debug.LogWarning($"[BetterInfoCards] Missing PrimaryElement for converter '{converterId}' on object '{go?.name ?? "<null>"}'. Using a safe default.");
         }
     }
 }


### PR DESCRIPTION
## Summary
- guard ore mass and temperature converters against missing PrimaryElement components
- return safe defaults and log a single warning when the component is absent

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ddf78371d48329bc38154ef6937c08