### PR TITLE
Add repository TODO tracker

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -1,0 +1,21 @@
+# Outstanding TODO Tracker
+
+This document inventories the current in-code `TODO` comments across the repository. Items may be checked off **only after** the corresponding in-code `TODO` comment has been removed **and** the affected behavior has been re-validated through tests or manual verification. Keep this list synchronized whenever TODOs are introduced or resolved.
+
+## TODO Summary
+
+| Status | Mod/Area | File | Summary |
+| --- | --- | --- | --- |
+| [ ] | DefaultBuildingSettings | `src/DefaultBuildingSettings/OnBuild_Patch.cs` | Revisit whether building configs can now be edited directly instead of relying on the current Harmony patch approach. |
+| [ ] | DefaultBuildingSettings | `src/DefaultBuildingSettings/OnBuild_Patch.cs` | If this patch logic becomes broadly useful again, consider extracting it into a reusable attribute-based helper. |
+| [ ] | AzeLib - Extensions | `src/AzeLib/Extensions/TranspilerExt.cs` | Optimize `MethodRemover` so it only emits stack pops when required and handles label preservation or fix-ups cleanly. |
+| [ ] | AzeLib - Extensions | `src/AzeLib/Extensions/TranspilerExt.cs` | Evaluate whether the operand-targeted `Manipulator` overload is sufficiently general to keep or should be removed. |
+| [ ] | AzeLib - Extensions | `src/AzeLib/Extensions/CodeInstructionExt.cs` | Provide documentation describing the available IL `CodeInstruction` extension methods. |
+| [ ] | AzeLib - Extensions | `src/AzeLib/Extensions/CodeInstructionExt.cs` | Refactor `GetLoadFromStore` into a cleaner, fully general solution for deriving load instructions from stores. |
+| [ ] | AzeLib - Attributes | `src/AzeLib/Attributes/AMonoBehaviour.cs` | Improve the attribute-driven field wiring to match the base game's optimized approach. |
+| [ ] | AzeLib - Core | `src/AzeLib/AzeMod.cs` | Benchmark the `OnLoad` hook to ensure the reflection-based initialization does not unduly impact load times. |
+| [ ] | Build Tooling | `src/AutoIncrement.targets` | Diagnose intermittent `RoslynCodeTaskFactory` reference resolution failures and modernize the task implementation with newer C# features. |
+| [ ] | BetterInfoCards - Util | `src/BetterInfoCards/Util/ResetPool.cs` | Consider adding logic to shrink the reset pool when demand drops. |
+| [ ] | BetterInfoCards - Converters | `src/BetterInfoCards/Converters/ConverterManager.cs` | Decide whether the default and title converters should live outside the shared converter dictionary for clarity or reuse. |
+
+*Last updated: 2025-10-02 03:57 UTC*


### PR DESCRIPTION
## Summary
- add a root-level TODO tracker that aggregates outstanding code TODO comments by mod or area
- document completion criteria to ensure TODO removal and behavior validation before closing items

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68ddf8157da08329b5ec00404d97616b