### PR TITLE
Configure default building settings via prefab edits

### DIFF
--- a/src/DefaultBuildingSettings/LoadGeneratedBuildings_Patch.cs
+++ b/src/DefaultBuildingSettings/LoadGeneratedBuildings_Patch.cs
@@ -1,4 +1,4 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 
 namespace DefaultBuildingSettings
 {
@@ -11,7 +11,8 @@ namespace DefaultBuildingSettings
             {
                 var go = def.BuildingComplete;
 
-                Generators.SetGeneratorValues(go);           
+                BuildingPrefabDefaults.Apply(go);
+                Generators.SetGeneratorValues(go);
             }
         }
     }

--- a/src/DefaultBuildingSettings/ManualVerification.md
+++ b/src/DefaultBuildingSettings/ManualVerification.md
@@ -1,0 +1,15 @@
+# Manual Verification Checklist
+
+The direct prefab edits replace the runtime Build postfix. Validate the following when testing the
+mod in-game:
+
+- Place a checkpoint: the Suit Marker should default to "Vacancy Only" without additional clicks.
+- Construct a manual access door that does not displace gas: it should open automatically a moment
+  after construction and stay open across save/load.
+- Build a smart reservoir: its activation and deactivation sliders should match the configured
+  percentages immediately after placement.
+- Build a generator with a delivery threshold (e.g. Coal Generator): confirm the slider defaults to
+  the configured value, ensuring the LoadGeneratedBuildings initialization still runs.
+
+Re-run the checklist after toggling any relevant options to confirm the prefab defaults respect the
+configuration.


### PR DESCRIPTION
## Summary
- move default building default logic into prefab initialization and drop the Build postfix
- add a helper component for doors so prefab edits keep the automatic-open behaviour
- document manual verification steps for the new prefab-based workflow

## Testing
- not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68ddf936f50083298cd6329bc16ce5c3