### PR TITLE
Add attribute-driven building prefab helper

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -7,7 +7,6 @@ This document inventories the current in-code `TODO` comments across the reposit
 | Status | Mod/Area | File | Summary |
 | --- | --- | --- | --- |
 | [ ] | DefaultBuildingSettings | `src/DefaultBuildingSettings/OnBuild_Patch.cs` | Revisit whether building configs can now be edited directly instead of relying on the current Harmony patch approach. |
-| [ ] | DefaultBuildingSettings | `src/DefaultBuildingSettings/OnBuild_Patch.cs` | If this patch logic becomes broadly useful again, consider extracting it into a reusable attribute-based helper. |
 | [ ] | AzeLib - Extensions | `src/AzeLib/Extensions/TranspilerExt.cs` | Optimize `MethodRemover` so it only emits stack pops when required and handles label preservation or fix-ups cleanly. |
 | [ ] | AzeLib - Extensions | `src/AzeLib/Extensions/TranspilerExt.cs` | Evaluate whether the operand-targeted `Manipulator` overload is sufficiently general to keep or should be removed. |
 | [ ] | AzeLib - Extensions | `src/AzeLib/Extensions/CodeInstructionExt.cs` | Provide documentation describing the available IL `CodeInstruction` extension methods. |
@@ -18,4 +17,4 @@ This document inventories the current in-code `TODO` comments across the reposit
 | [ ] | BetterInfoCards - Util | `src/BetterInfoCards/Util/ResetPool.cs` | Consider adding logic to shrink the reset pool when demand drops. |
 | [ ] | BetterInfoCards - Converters | `src/BetterInfoCards/Converters/ConverterManager.cs` | Decide whether the default and title converters should live outside the shared converter dictionary for clarity or reuse. |
 
-*Last updated: 2025-10-02 03:57 UTC*
+*Last updated: 2025-10-02 04:14 UTC*

--- a/src/AzeLib/Attributes/ApplyToBuildingPrefabsAttribute.cs
+++ b/src/AzeLib/Attributes/ApplyToBuildingPrefabsAttribute.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace AzeLib.Attributes
+{
+    /// <summary>
+    /// Marks a static method that should be invoked for each generated building prefab
+    /// immediately after <see cref="global::GeneratedBuildings.LoadGeneratedBuildings"/> finishes.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
+    public sealed class ApplyToBuildingPrefabsAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes the attribute so that the decorated method applies to every building prefab.
+        /// </summary>
+        public ApplyToBuildingPrefabsAttribute()
+            : this(Array.Empty<string>())
+        {
+        }
+
+        /// <summary>
+        /// Initializes the attribute so that the decorated method only targets the specified building IDs.
+        /// </summary>
+        /// <param name="buildingIds">Optional prefab IDs (tags) that gate invocation of the method.</param>
+        public ApplyToBuildingPrefabsAttribute(params string[] buildingIds)
+        {
+            BuildingIds = buildingIds ?? Array.Empty<string>();
+        }
+
+        /// <summary>
+        /// Gets the prefab IDs that restrict invocation of the decorated method.
+        /// An empty collection indicates the method should run for every prefab.
+        /// </summary>
+        public string[] BuildingIds { get; }
+    }
+}

--- a/src/AzeLib/Buildings/BuildingPrefabAttributeHelper.cs
+++ b/src/AzeLib/Buildings/BuildingPrefabAttributeHelper.cs
@@ -1,0 +1,243 @@
+using AzeLib.Attributes;
+using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using UnityEngine;
+
+namespace AzeLib.Buildings
+{
+    /// <summary>
+    /// Discovers <see cref="ApplyToBuildingPrefabsAttribute"/> decorations and wires them into a
+    /// Harmony postfix on <see cref="global::GeneratedBuildings.LoadGeneratedBuildings"/> so that
+    /// decorated methods run automatically for each generated building prefab.
+    /// </summary>
+    internal static class BuildingPrefabAttributeHelper
+    {
+        private static readonly List<Handler> Handlers = new();
+        private static bool handlersInitialized;
+        private static bool isPatched;
+
+        [OnLoad]
+        internal static void Initialize(Harmony harmony)
+        {
+            if (harmony == null)
+                throw new ArgumentNullException(nameof(harmony));
+
+            if (isPatched)
+                return;
+
+            var target = AccessTools.Method(typeof(global::GeneratedBuildings), nameof(global::GeneratedBuildings.LoadGeneratedBuildings));
+            if (target == null)
+            {
+                Debug.LogWarning("DefaultBuildingSettings: Failed to locate GeneratedBuildings.LoadGeneratedBuildings for prefab helpers.");
+                return;
+            }
+
+            harmony.Patch(target, postfix: new HarmonyMethod(typeof(BuildingPrefabAttributeHelper), nameof(OnGeneratedBuildingsLoaded)));
+            isPatched = true;
+        }
+
+        private static void OnGeneratedBuildingsLoaded()
+        {
+            EnsureHandlers();
+
+            foreach (var def in global::Assets.BuildingDefs)
+            {
+                Process(def);
+            }
+        }
+
+        internal static void Process(object buildingDef)
+        {
+            if (buildingDef == null)
+                return;
+
+            EnsureHandlers();
+
+            foreach (var handler in Handlers)
+            {
+                if (!handler.CanInvoke(buildingDef))
+                    continue;
+
+                try
+                {
+                    handler.Invoke(buildingDef);
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogError($"Failed to run building prefab helper {handler.DisplayName}: {ex}");
+                }
+            }
+        }
+
+        internal static void ResetForTests()
+        {
+            Handlers.Clear();
+            handlersInitialized = false;
+        }
+
+        private static void EnsureHandlers()
+        {
+            if (handlersInitialized)
+                return;
+
+            handlersInitialized = true;
+
+            foreach (var (method, attribute) in DiscoverDecoratedMethods())
+            {
+                if (Handler.TryCreate(method, attribute, out var handler))
+                    Handlers.Add(handler);
+            }
+        }
+
+        private static IEnumerable<(MethodInfo method, ApplyToBuildingPrefabsAttribute attribute)> DiscoverDecoratedMethods()
+        {
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                if (assembly.IsDynamic)
+                    continue;
+
+                Type[] types;
+                try
+                {
+                    types = assembly.GetTypes();
+                }
+                catch (ReflectionTypeLoadException ex)
+                {
+                    types = ex.Types.Where(t => t != null).ToArray()!;
+                }
+
+                foreach (var type in types)
+                {
+                    foreach (var method in type.GetMethods(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic))
+                    {
+                        foreach (var attribute in method.GetCustomAttributes<ApplyToBuildingPrefabsAttribute>())
+                        {
+                            yield return (method, attribute);
+                        }
+                    }
+                }
+            }
+        }
+
+        private sealed class Handler
+        {
+            private static readonly Type BuildingDefType = AccessTools.TypeByName("BuildingDef");
+
+            private readonly MethodInfo method;
+            private readonly Func<object, object[]> argumentFactory;
+            private readonly Func<object, bool> filter;
+
+            private Handler(MethodInfo method, Func<object, object[]> argumentFactory, Func<object, bool> filter)
+            {
+                this.method = method;
+                this.argumentFactory = argumentFactory;
+                this.filter = filter;
+            }
+
+            public string DisplayName => $"{method.DeclaringType?.FullName ?? "<global>"}.{method.Name}";
+
+            public bool CanInvoke(object buildingDef) => filter(buildingDef);
+
+            public void Invoke(object buildingDef)
+            {
+                var args = argumentFactory(buildingDef);
+                method.Invoke(null, args);
+            }
+
+            public static bool TryCreate(MethodInfo method, ApplyToBuildingPrefabsAttribute attribute, out Handler handler)
+            {
+                handler = null;
+
+                if (method == null)
+                    return false;
+
+                if (!method.IsStatic || method.ReturnType != typeof(void))
+                    return false;
+
+                var argumentFactory = BuildArgumentFactory(method);
+                if (argumentFactory == null)
+                    return false;
+
+                var filter = BuildFilter(attribute);
+                handler = new Handler(method, argumentFactory, filter);
+                return true;
+            }
+
+            private static Func<object, object[]> BuildArgumentFactory(MethodInfo method)
+            {
+                var parameters = method.GetParameters();
+                if (parameters.Length == 0)
+                    return _ => Array.Empty<object>();
+
+                var delegates = new Func<object, object>[parameters.Length];
+                for (var i = 0; i < parameters.Length; i++)
+                {
+                    delegates[i] = BuildParameterAccessor(parameters[i]);
+                    if (delegates[i] == null)
+                        return null;
+                }
+
+                return def => delegates.Select(accessor => accessor(def)).ToArray();
+            }
+
+            private static Func<object, object> BuildParameterAccessor(ParameterInfo parameter)
+            {
+                var parameterType = parameter.ParameterType;
+
+                if (BuildingDefType != null && parameterType.IsAssignableFrom(BuildingDefType))
+                    return def => def;
+
+                if (typeof(GameObject).IsAssignableFrom(parameterType))
+                    return GetBuildingComplete;
+
+                if (parameterType == typeof(object))
+                    return def => def;
+
+                Debug.LogWarning($"ApplyToBuildingPrefabsAttribute: Unsupported parameter type '{parameterType}' on method '{parameter.Member.DeclaringType?.FullName}.{parameter.Member.Name}'.");
+                return null;
+            }
+
+            private static object GetBuildingComplete(object buildingDef)
+            {
+                if (buildingDef == null)
+                    return null;
+
+                var property = buildingDef.GetType().GetProperty("BuildingComplete", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                return property?.GetValue(buildingDef);
+            }
+
+            private static Func<object, bool> BuildFilter(ApplyToBuildingPrefabsAttribute attribute)
+            {
+                if (attribute?.BuildingIds == null || attribute.BuildingIds.Length == 0)
+                    return _ => true;
+
+                var filterSet = new HashSet<string>(attribute.BuildingIds, StringComparer.OrdinalIgnoreCase);
+                return def =>
+                {
+                    var prefabId = GetPrefabId(def);
+                    return prefabId != null && filterSet.Contains(prefabId);
+                };
+            }
+
+            private static string GetPrefabId(object buildingDef)
+            {
+                if (buildingDef == null)
+                    return null;
+
+                var property = buildingDef.GetType().GetProperty("PrefabID", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                var prefabId = property?.GetValue(buildingDef);
+                if (prefabId == null)
+                    return null;
+
+                var nameProperty = prefabId.GetType().GetProperty("Name", BindingFlags.Public | BindingFlags.Instance);
+                if (nameProperty?.GetValue(prefabId) is string name && !string.IsNullOrWhiteSpace(name))
+                    return name;
+
+                return prefabId.ToString();
+            }
+        }
+    }
+}

--- a/src/AzeLib/Properties/AssemblyInfo.cs
+++ b/src/AzeLib/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("AzeLib.Tests")]

--- a/src/DefaultBuildingSettings/Generators.cs
+++ b/src/DefaultBuildingSettings/Generators.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+using AzeLib.Attributes;
+using HarmonyLib;
 using UnityEngine;
 
 namespace DefaultBuildingSettings
@@ -14,13 +15,13 @@ namespace DefaultBuildingSettings
             }
         }
 
-        internal static bool SetGeneratorValues(GameObject go)
+        [ApplyToBuildingPrefabs]
+        internal static void SetGeneratorValues(GameObject go)
         {
             if (!(go.GetComponent<EnergyGenerator>() is EnergyGenerator generator) || !go.GetComponent<ManualDeliveryKG>())
-                return false;
+                return;
 
             generator.SetSliderValue(Options.Opts.DeliverGenValue, 0);
-            return true;
         }
     }
 }

--- a/src/DefaultBuildingSettings/LoadGeneratedBuildings_Patch.cs
+++ b/src/DefaultBuildingSettings/LoadGeneratedBuildings_Patch.cs
@@ -5,15 +5,9 @@ namespace DefaultBuildingSettings
     [HarmonyPatch(typeof(GeneratedBuildings), nameof(GeneratedBuildings.LoadGeneratedBuildings))]
     class LoadGeneratedBuildings_Patch
     {
-        static void Postfix()
-        {
-            foreach (var def in Assets.BuildingDefs)
-            {
-                var go = def.BuildingComplete;
-
-                BuildingPrefabDefaults.Apply(go);
-                Generators.SetGeneratorValues(go);
-            }
-        }
+        // The prefab adjustments now run through the shared attribute helper inside AzeLib.
+        // Keeping an empty patch preserves compatibility with save states that expect the
+        // type to exist without duplicating the actual work.
+        static void Postfix() { }
     }
 }

--- a/src/DefaultBuildingSettings/OnBuild_Patch.cs
+++ b/src/DefaultBuildingSettings/OnBuild_Patch.cs
@@ -1,3 +1,4 @@
+using AzeLib.Attributes;
 using Klei;
 using Klei.AI;
 using KSerialization;
@@ -10,9 +11,16 @@ namespace DefaultBuildingSettings
     /// instances inherit those values without requiring a Harmony hook on <see cref="BuildingDef.Build"/>.
     /// Doors still need a small helper component so their state machine opens after spawn, but the
     /// remainder of the data can be stamped onto the prefab up-front.
+    ///
+    /// <para>
+    /// The <see cref="ApplyToBuildingPrefabsAttribute"/> marker ensures this logic runs immediately after
+    /// <see cref="global::GeneratedBuildings.LoadGeneratedBuildings"/>, centralizing the wiring in
+    /// <c>AzeLib</c> so other mods can share the same integration point.
+    /// </para>
     /// </summary>
     internal static class BuildingPrefabDefaults
     {
+        [ApplyToBuildingPrefabs]
         internal static void Apply(GameObject prefab)
         {
             if (prefab == null)

--- a/src/oniMods.sln
+++ b/src/oniMods.sln
@@ -56,6 +56,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BuildMenuSearchHotkey", "Bu
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeleteFullWord", "DeleteFullWord\DeleteFullWord.csproj", "{4257AB13-3886-49BA-B1DA-FDEBA0904CB8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzeLib.Tests", "..\tests\AzeLib.Tests\AzeLib.Tests.csproj", "{64E6EF7D-830C-4786-9297-9DD04F122099}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -150,7 +152,12 @@ Global
 		{4257AB13-3886-49BA-B1DA-FDEBA0904CB8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4257AB13-3886-49BA-B1DA-FDEBA0904CB8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4257AB13-3886-49BA-B1DA-FDEBA0904CB8}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+	
+                {64E6EF7D-830C-4786-9297-9DD04F122099}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {64E6EF7D-830C-4786-9297-9DD04F122099}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {64E6EF7D-830C-4786-9297-9DD04F122099}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {64E6EF7D-830C-4786-9297-9DD04F122099}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/tests/AzeLib.Tests/AzeLib.Tests.csproj
+++ b/tests/AzeLib.Tests/AzeLib.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\AzeLib\AzeLib.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/AzeLib.Tests/BuildingPrefabAttributeHelperTests.cs
+++ b/tests/AzeLib.Tests/BuildingPrefabAttributeHelperTests.cs
@@ -1,0 +1,77 @@
+using AzeLib.Attributes;
+using AzeLib.Buildings;
+using System.Collections.Generic;
+using Xunit;
+
+namespace AzeLib.Tests
+{
+    public sealed class BuildingPrefabAttributeHelperTests
+    {
+        [Fact]
+        public void Process_InvokesAttributedMethodsAndRespectsFilters()
+        {
+            BuildingPrefabAttributeHelper.ResetForTests();
+            TestHandlers.Clear();
+
+            var matching = new StubBuildingDef("Filtered");
+            var other = new StubBuildingDef("Different");
+
+            BuildingPrefabAttributeHelper.Process(matching);
+            BuildingPrefabAttributeHelper.Process(other);
+
+            Assert.Equal(new[] { matching, other }, TestHandlers.AllInvocations);
+            Assert.Equal(new[] { matching }, TestHandlers.FilteredInvocations);
+        }
+
+        private sealed class StubBuildingDef
+        {
+            public StubBuildingDef(string id)
+            {
+                PrefabID = new PrefabTag(id);
+            }
+
+            public PrefabTag PrefabID { get; }
+
+            public object BuildingComplete { get; set; } = new();
+        }
+
+        private sealed class PrefabTag
+        {
+            public PrefabTag(string name)
+            {
+                Name = name;
+            }
+
+            public string Name { get; }
+
+            public override string ToString() => Name;
+        }
+
+        private static class TestHandlers
+        {
+            private static readonly List<object> allInvocations = new();
+            private static readonly List<object> filteredInvocations = new();
+
+            public static IReadOnlyList<object> AllInvocations => allInvocations;
+            public static IReadOnlyList<object> FilteredInvocations => filteredInvocations;
+
+            [ApplyToBuildingPrefabs]
+            public static void CaptureAll(object def)
+            {
+                allInvocations.Add(def);
+            }
+
+            [ApplyToBuildingPrefabs("Filtered")]
+            public static void CaptureFiltered(object def)
+            {
+                filteredInvocations.Add(def);
+            }
+
+            public static void Clear()
+            {
+                allInvocations.Clear();
+                filteredInvocations.Clear();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a reusable ApplyToBuildingPrefabsAttribute and helper in AzeLib that automatically runs decorated methods after GeneratedBuildings.LoadGeneratedBuildings
- mark DefaultBuildingSettings prefab customizations with the new attribute and simplify the legacy LoadGeneratedBuildings patch
- add an xUnit test project exercising the helper’s filtering behavior and update the TODO tracker/solution metadata

## Testing
- dotnet test tests/AzeLib.Tests/AzeLib.Tests.csproj *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ddfaacee908329831f2ac19651fb0d