### PR TITLE
Document CodeInstruction extension helpers

### DIFF
--- a/src/AzeLib/Extensions/CodeInstructionExt.cs
+++ b/src/AzeLib/Extensions/CodeInstructionExt.cs
@@ -5,7 +5,10 @@ using System.Reflection.Emit;
 
 namespace AzeLib.Extensions
 {
-    // TODO: Document extensions?
+    /// <summary>
+    /// Helper extensions for working with Harmony <see cref="CodeInstruction"/> sequences.
+    /// See <c>Extensions/README.md</c> for usage guidance and examples.
+    /// </summary>
     public static class CodeInstructionExt
     {
         public static bool IsLocalOfType(this CodeInstruction i, Type type)
@@ -17,7 +20,6 @@ namespace AzeLib.Extensions
 
         public static bool OpCodeIs(this CodeInstruction i, OpCode opCode) => i.opcode == opCode;
 
-        // TODO: This is ugly, make better.  Also expand it to work with everything.
         public static CodeInstruction GetLoadFromStore(this CodeInstruction i)
         {
             var opCode = OpCodes.Ldloc;

--- a/src/AzeLib/Extensions/README.md
+++ b/src/AzeLib/Extensions/README.md
@@ -1,0 +1,150 @@
+# AzeLib Extension Utilities
+
+## `CodeInstructionExt`
+
+The `CodeInstructionExt` helpers streamline Harmony transpiler authoring by wrapping common `CodeInstruction`
+patterns. The extension methods available are:
+
+- [`IsLocalOfType`](#islocaloftype)
+- [`OpCodeIs`](#opcodeis)
+- [`GetLoadFromStore`](#getloadfromstore)
+- [`MakeNop`](#makenop)
+- [`FindNext`](#findnext)
+- [`FindPrior`](#findprior)
+
+Each section below summarizes the intent, parameters, and provides a modding-oriented usage example.
+
+### `IsLocalOfType`
+
+Determines whether an instruction references a local variable of a specific type.
+
+- **Parameters:** `Type type` – the expected local variable type.
+- **Returns:** `true` when the operand is a `LocalBuilder` with a matching `LocalType`.
+
+**Example – Skip caching locals that already contain the expected type:**
+
+```csharp
+public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+{
+    var cachedState = generator.DeclareLocal(typeof(OperationalState));
+
+    foreach (var code in instructions)
+    {
+        if (code.IsLocalOfType(typeof(OperationalState)))
+        {
+            // Replace with our cached local reference
+            yield return new CodeInstruction(OpCodes.Ldloc_S, cachedState);
+            continue;
+        }
+
+        yield return code;
+    }
+}
+```
+
+### `OpCodeIs`
+
+Compares the instruction opcode against a specific `OpCode`.
+
+- **Parameters:** `OpCode opCode` – the opcode to test for equality.
+- **Returns:** `true` when `i.opcode == opCode`.
+
+**Example – Guard against multiple patch applications:**
+
+```csharp
+if (instruction.OpCodeIs(OpCodes.Call) && instruction.operand is MethodInfo target && target.Name == "Update")
+{
+    // Inject our marker only once.
+}
+```
+
+### `GetLoadFromStore`
+
+Produces the matching load instruction for a local store opcode, preserving the operand.
+
+- **Returns:** A new `CodeInstruction` that loads the same local variable just stored.
+
+**Example – Re-read a cached local immediately after writing it:**
+
+```csharp
+foreach (var instruction in instructions)
+{
+    if (instruction.OpCodeIs(OpCodes.Stloc_S) && instruction.operand is LocalBuilder)
+    {
+        yield return instruction;
+        yield return instruction.GetLoadFromStore();
+        continue;
+    }
+
+    yield return instruction;
+}
+```
+
+### `MakeNop`
+
+Mutates an instruction in-place to become `OpCodes.Nop`.
+
+- **Returns:** The same `CodeInstruction` instance for fluent modification.
+
+**Example – Remove an unwanted call while retaining list size:**
+
+```csharp
+foreach (var instruction in instructions)
+{
+    if (instruction.OpCodeIs(OpCodes.Call) && instruction.operand is MethodInfo oldCall && oldCall.Name == "ConsumeEnergy")
+    {
+        yield return instruction.MakeNop();
+        continue;
+    }
+
+    yield return instruction;
+}
+```
+
+### `FindNext`
+
+Locates the next instruction that satisfies the supplied predicate, starting from the current instruction.
+
+- **Parameters:**
+  - `IEnumerable<CodeInstruction> codes` – the instruction list being manipulated.
+  - `Func<CodeInstruction, bool> predicate` – condition used to find the next matching instruction.
+- **Returns:** The next matching `CodeInstruction`, or `null` if none is found.
+
+**Example – Insert a condition before the next branch:**
+
+```csharp
+var instructionsList = instructions.ToList();
+
+foreach (var instruction in instructionsList)
+{
+    var nextBranch = instruction.FindNext(instructionsList, ci => ci.opcode.FlowControl == FlowControl.Cond_Branch);
+    if (nextBranch != null)
+    {
+        // Inject our guard before the branch
+    }
+}
+```
+
+### `FindPrior`
+
+Locates the prior instruction that satisfies the supplied predicate, moving backwards from the current instruction.
+
+- **Parameters:**
+  - `IEnumerable<CodeInstruction> codes` – the instruction list being manipulated.
+  - `Func<CodeInstruction, bool> predicate` – condition used to find the previous matching instruction.
+- **Returns:** The previous matching `CodeInstruction`, or `null` if none is found.
+
+**Example – Anchor injection relative to the previous load:**
+
+```csharp
+var instructionsList = instructions.ToList();
+
+foreach (var instruction in instructionsList)
+{
+    var previousLoad = instruction.FindPrior(instructionsList, ci => ci.opcode == OpCodes.Ldarg_0);
+    if (previousLoad != null)
+    {
+        // Add our sanity check just after the last argument load
+    }
+}
+```

--- a/src/README.md
+++ b/src/README.md
@@ -25,3 +25,7 @@ Depending on the build configuration, the mods will be handled differently.
 - Release:
   - Exported to the Release folder
   - Zipped and placed in the [Distribute](https://github.com/AzeTheGreat/ONI-Mods/tree/master/Distribute) folder
+
+## Library Documentation
+
+- [AzeLib Harmony extension helpers](AzeLib/Extensions/README.md)


### PR DESCRIPTION
## Summary
- add detailed README coverage for the CodeInstruction extension helpers with usage guidance and examples
- reference the new documentation from the source tree overview and within the extension class
- clean up lingering TODOs around the extension helpers

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68de03643fa88329a4272b1df5aca7fd