### PR TITLE
Improve ResetPool tracking and trimming

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -14,7 +14,7 @@ This document inventories the current in-code `TODO` comments across the reposit
 | [ ] | AzeLib - Attributes | `src/AzeLib/Attributes/AMonoBehaviour.cs` | Improve the attribute-driven field wiring to match the base game's optimized approach. |
 | [ ] | AzeLib - Core | `src/AzeLib/AzeMod.cs` | Benchmark the `OnLoad` hook to ensure the reflection-based initialization does not unduly impact load times. |
 | [ ] | Build Tooling | `src/AutoIncrement.targets` | Diagnose intermittent `RoslynCodeTaskFactory` reference resolution failures and modernize the task implementation with newer C# features. |
-| [ ] | BetterInfoCards - Util | `src/BetterInfoCards/Util/ResetPool.cs` | Consider adding logic to shrink the reset pool when demand drops. |
+| [x] | BetterInfoCards - Util | `src/BetterInfoCards/Util/ResetPool.cs` | Consider adding logic to shrink the reset pool when demand drops. |
 | [ ] | BetterInfoCards - Converters | `src/BetterInfoCards/Converters/ConverterManager.cs` | Decide whether the default and title converters should live outside the shared converter dictionary for clarity or reuse. |
 
 *Last updated: 2025-10-02 04:23 UTC*

--- a/src/BetterInfoCards/Util/ResetPool.cs
+++ b/src/BetterInfoCards/Util/ResetPool.cs
@@ -1,33 +1,183 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
 
 namespace BetterInfoCards
 {
     public class ResetPool<T> where T : new()
     {
-        private List<T> pool = new();
-        private int currentlyUsedIndex;
+        private static readonly double StopwatchToTimeSpanRatio = (double)TimeSpan.TicksPerSecond / Stopwatch.Frequency;
 
-        public ResetPool(ref System.Action resetOn)
+        private readonly List<T> pool = new();
+        private readonly List<long> lastUsedTicks = new();
+        private readonly object sync = new();
+        private readonly int lowUsageCyclesBeforeTrim;
+        private readonly double lowUsageRatio;
+        private readonly double trimSlack;
+        private readonly long idleTrimThreshold;
+
+        private int currentlyUsedIndex;
+        private int highWatermark;
+        private int consecutiveLowUsageCycles;
+        private int lastCycleUsage;
+        private long lastResetTimestamp;
+
+        public ResetPool(
+            ref Action resetOn,
+            int lowUsageCyclesBeforeTrim = 3,
+            double lowUsageRatio = 0.5,
+            double trimSlack = 0.25,
+            TimeSpan? idleTrimAge = null)
         {
-            resetOn += () => Reset();
+            if (lowUsageCyclesBeforeTrim < 1)
+                throw new ArgumentOutOfRangeException(nameof(lowUsageCyclesBeforeTrim));
+            if (lowUsageRatio <= 0d || lowUsageRatio > 1d)
+                throw new ArgumentOutOfRangeException(nameof(lowUsageRatio));
+            if (trimSlack < 0d)
+                throw new ArgumentOutOfRangeException(nameof(trimSlack));
+
+            this.lowUsageCyclesBeforeTrim = lowUsageCyclesBeforeTrim;
+            this.lowUsageRatio = lowUsageRatio;
+            this.trimSlack = trimSlack;
+            idleTrimThreshold = ToStopwatchTicks(idleTrimAge ?? TimeSpan.FromSeconds(30));
+
+            resetOn += Reset;
+        }
+
+        public int Count
+        {
+            get
+            {
+                lock (sync)
+                {
+                    return pool.Count;
+                }
+            }
+        }
+
+        public int CurrentlyUsed => Volatile.Read(ref currentlyUsedIndex);
+
+        public int HighWatermark => Volatile.Read(ref highWatermark);
+
+        public int LastCycleUsage => Volatile.Read(ref lastCycleUsage);
+
+        public TimeSpan GetIdleTimeFor(int index)
+        {
+            lock (sync)
+            {
+                if ((uint)index >= (uint)pool.Count)
+                    throw new ArgumentOutOfRangeException(nameof(index));
+
+                long now = Stopwatch.GetTimestamp();
+                long lastUsed = lastUsedTicks[index];
+                return StopwatchTicksToTimeSpan(now - lastUsed);
+            }
+        }
+
+        public TimeSpan TimeSinceLastReset()
+        {
+            long snapshot = Interlocked.Read(ref lastResetTimestamp);
+            if (snapshot == 0)
+                return TimeSpan.MaxValue;
+
+            long now = Stopwatch.GetTimestamp();
+            return StopwatchTicksToTimeSpan(now - snapshot);
         }
 
         public T Get()
         {
-            T obj;
-            if (currentlyUsedIndex < pool.Count)
-                obj = pool[currentlyUsedIndex];
-            else
-                pool.Add(obj = new());
+            lock (sync)
+            {
+                int index = currentlyUsedIndex;
+                T obj;
+                long now = Stopwatch.GetTimestamp();
 
-            currentlyUsedIndex++;
-            return obj;
+                if (index < pool.Count)
+                {
+                    obj = pool[index];
+                    lastUsedTicks[index] = now;
+                }
+                else
+                {
+                    obj = new T();
+                    pool.Add(obj);
+                    lastUsedTicks.Add(now);
+                }
+
+                currentlyUsedIndex = index + 1;
+                return obj;
+            }
         }
 
-        // TODO: Implement pool downsizing?
         private void Reset()
         {
-            currentlyUsedIndex = 0;
+            lock (sync)
+            {
+                int usedThisCycle = currentlyUsedIndex;
+                currentlyUsedIndex = 0;
+                lastCycleUsage = usedThisCycle;
+
+                if (usedThisCycle > highWatermark)
+                    highWatermark = usedThisCycle;
+
+                long now = Stopwatch.GetTimestamp();
+                Interlocked.Exchange(ref lastResetTimestamp, now);
+
+                if (pool.Count == 0)
+                {
+                    consecutiveLowUsageCycles = 0;
+                    return;
+                }
+
+                bool lowUsage = usedThisCycle == 0 || usedThisCycle <= Math.Floor(pool.Count * lowUsageRatio);
+                consecutiveLowUsageCycles = lowUsage ? consecutiveLowUsageCycles + 1 : 0;
+
+                if (consecutiveLowUsageCycles >= lowUsageCyclesBeforeTrim)
+                {
+                    TrimPool(now, usedThisCycle);
+                    consecutiveLowUsageCycles = 0;
+                }
+            }
+        }
+
+        private void TrimPool(long now, int requiredCount)
+        {
+            if (pool.Count == 0)
+                return;
+
+            int buffer = requiredCount == 0
+                ? 0
+                : Math.Max(1, (int)Math.Ceiling(requiredCount * trimSlack));
+            int target = Math.Min(pool.Count, requiredCount + buffer);
+
+            for (int i = pool.Count - 1; i >= target; i--)
+            {
+                long idleTicks = now - lastUsedTicks[i];
+                if (idleTicks < idleTrimThreshold)
+                    continue;
+
+                pool.RemoveAt(i);
+                lastUsedTicks.RemoveAt(i);
+            }
+        }
+
+        private static long ToStopwatchTicks(TimeSpan duration)
+        {
+            if (duration == Timeout.InfiniteTimeSpan)
+                return long.MaxValue;
+
+            double ticks = duration.Ticks * (double)Stopwatch.Frequency / TimeSpan.TicksPerSecond;
+            return ticks < 0 ? 0 : (long)ticks;
+        }
+
+        private static TimeSpan StopwatchTicksToTimeSpan(long ticks)
+        {
+            if (ticks <= 0)
+                return TimeSpan.Zero;
+
+            long durationTicks = (long)(ticks * StopwatchToTimeSpanRatio);
+            return TimeSpan.FromTicks(Math.Max(0, durationTicks));
         }
     }
 }

--- a/src/oniMods.sln
+++ b/src/oniMods.sln
@@ -58,6 +58,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeleteFullWord", "DeleteFul
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzeLib.Tests", "..\tests\AzeLib.Tests\AzeLib.Tests.csproj", "{64E6EF7D-830C-4786-9297-9DD04F122099}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BetterInfoCards.Tests", "..\tests\BetterInfoCards.Tests\BetterInfoCards.Tests.csproj", "{E0CE553E-E5BD-4D08-8E07-D91F4A760BAC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -157,6 +159,10 @@ Global
                 {64E6EF7D-830C-4786-9297-9DD04F122099}.Debug|Any CPU.Build.0 = Debug|Any CPU
                 {64E6EF7D-830C-4786-9297-9DD04F122099}.Release|Any CPU.ActiveCfg = Release|Any CPU
                 {64E6EF7D-830C-4786-9297-9DD04F122099}.Release|Any CPU.Build.0 = Release|Any CPU
+                {E0CE553E-E5BD-4D08-8E07-D91F4A760BAC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {E0CE553E-E5BD-4D08-8E07-D91F4A760BAC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {E0CE553E-E5BD-4D08-8E07-D91F4A760BAC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {E0CE553E-E5BD-4D08-8E07-D91F4A760BAC}.Release|Any CPU.Build.0 = Release|Any CPU
         EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/tests/BetterInfoCards.Tests/BetterInfoCards.Tests.csproj
+++ b/tests/BetterInfoCards.Tests/BetterInfoCards.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\BetterInfoCards\BetterInfoCards.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/BetterInfoCards.Tests/ResetPoolTests.cs
+++ b/tests/BetterInfoCards.Tests/ResetPoolTests.cs
@@ -1,0 +1,54 @@
+using System;
+using BetterInfoCards;
+using Xunit;
+
+namespace BetterInfoCards.Tests
+{
+    public sealed class ResetPoolTests
+    {
+        private sealed class Dummy
+        {
+        }
+
+        [Fact]
+        public void TracksHighWatermarkAcrossGrowth()
+        {
+            Action reset = () => { };
+            var pool = new ResetPool<Dummy>(ref reset);
+
+            _ = pool.Get();
+            _ = pool.Get();
+            reset();
+
+            Assert.Equal(2, pool.HighWatermark);
+            Assert.Equal(2, pool.LastCycleUsage);
+            Assert.Equal(2, pool.Count);
+        }
+
+        [Fact]
+        public void ShrinksPoolAfterRepeatedLowUsage()
+        {
+            Action reset = () => { };
+            var pool = new ResetPool<Dummy>(
+                ref reset,
+                lowUsageCyclesBeforeTrim: 2,
+                lowUsageRatio: 0.6,
+                trimSlack: 0,
+                idleTrimAge: TimeSpan.Zero);
+
+            for (int i = 0; i < 6; i++)
+                _ = pool.Get();
+            reset();
+
+            // Only rent a single instance for two consecutive cycles.
+            _ = pool.Get();
+            reset();
+            _ = pool.Get();
+            reset();
+
+            Assert.Equal(6, pool.HighWatermark);
+            Assert.Equal(1, pool.Count);
+            Assert.Equal(1, pool.LastCycleUsage);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extend `ResetPool<T>` with thread-safe high-watermark tracking, idle metrics, and configurable downsizing logic
- add a BetterInfoCards test project with growth and shrink coverage for the pool
- update the outstanding TODO entry now that the pool can contract when demand falls

## Testing
- `dotnet test src/oniMods.sln` *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de2480abd48329ba51071735e79843