### PR TITLE
Document AutoIncrement verification

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -21,6 +21,7 @@
 - Updated `src/AutoIncrement.targets` to load `RoslynCodeTaskFactory` from `$(MSBuildToolsPath)` with explicit `UsingTask` metadata so the factory resolves consistently across runtimes.
 - Refactored the embedded task to use structured helpers, regex-based JSON parsing, and culture-invariant formatting while preserving the existing `version.json` contract.
 - Validated the task in isolation via `dotnet msbuild src/AzeLib/AzeLib.csproj /t:AutoIncrement /p:Configuration=Debug`, confirming the revision value increments and the new serializer output remains stable.
+- Re-reviewed the modernized implementation on 2025-10-02 to confirm the documentation matches the committed Roslyn task structure and versioning flow.
 
 ## 2025-10-05 - BetterInfoCards converter registry
 - Split the default (raw text) and title converters out of the general registry to keep fallback lookups deterministic and prevent accidental overrides.

--- a/ToDo.md
+++ b/ToDo.md
@@ -13,8 +13,8 @@ This document inventories the current in-code `TODO` comments across the reposit
 | [x] | AzeLib - Extensions | `src/AzeLib/Extensions/CodeInstructionExt.cs` | Refactor `GetLoadFromStore` into a cleaner, fully general solution for deriving load instructions from stores. |
 | [x] | AzeLib - Attributes | `src/AzeLib/Attributes/AMonoBehaviour.cs` | Confirmed cached attribute-driven field wiring matches the base game's optimized approach. |
 | [x] | AzeLib - Core | `src/AzeLib/AzeMod.cs` | Benchmark the `OnLoad` hook to ensure the reflection-based initialization does not unduly impact load times. |
-| [ ] | Build Tooling | `src/AutoIncrement.targets` | Diagnose intermittent `RoslynCodeTaskFactory` reference resolution failures and modernize the task implementation with newer C# features. |
+| [x] | Build Tooling | `src/AutoIncrement.targets` | Modernized the AutoIncrement inline task to resolve `RoslynCodeTaskFactory` via `$(MSBuildToolsPath)` and hardened the JSON parser/serializer across runtimes. |
 | [x] | BetterInfoCards - Util | `src/BetterInfoCards/Util/ResetPool.cs` | Consider adding logic to shrink the reset pool when demand drops. |
 | [x] | BetterInfoCards - Converters | `src/BetterInfoCards/Converters/ConverterManager.cs` | Decide whether the default and title converters should live outside the shared converter dictionary for clarity or reuse. |
 
-*Last updated: 2025-10-02 07:57 UTC*
+*Last updated: 2025-10-02 07:59 UTC*


### PR DESCRIPTION
## Summary
- Recorded the follow-up verification of the modernized AutoIncrement inline task in the maintainer notes.
- Checked off the Build Tooling tracker entry now that the Roslyn task updates and JSON hardening are complete, and refreshed the status timestamp.

## Testing
- Not run (documentation-only changes).


------
https://chatgpt.com/codex/tasks/task_e_68de30b8ea888329afd0d67c82b32448