### PR TITLE
Handle null inputs in RemoveCountSuffix

### DIFF
--- a/src/BetterInfoCards/Util/Extensions.cs
+++ b/src/BetterInfoCards/Util/Extensions.cs
@@ -4,6 +4,9 @@
     {
         public static string RemoveCountSuffix(this string s)
         {
+            if (string.IsNullOrEmpty(s))
+                return s;
+
             if (!char.IsDigit(s[s.Length - 1]))
                 return s;
 

--- a/tests/BetterInfoCards.Tests/ConverterManagerTests.cs
+++ b/tests/BetterInfoCards.Tests/ConverterManagerTests.cs
@@ -31,5 +31,16 @@ namespace BetterInfoCards.Tests
             Assert.True(ConverterManager.TryGetConverter(ConverterManager.germs, out var converter));
             Assert.NotNull(converter);
         }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData("", "")]
+        [InlineData("Info x 3", "Info")]
+        public void RemoveCountSuffixHandlesEdgeCases(string input, string expected)
+        {
+            var result = Extensions.RemoveCountSuffix(input);
+
+            Assert.Equal(expected, result);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add a null/empty guard to `RemoveCountSuffix` to avoid dereferencing empty strings
- extend the BetterInfoCards tests to cover null, empty, and suffixed input values

## Testing
- Attempted `dotnet test tests/BetterInfoCards.Tests/BetterInfoCards.Tests.csproj` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68de33a9b5748329b532d491720f28ea