### PR TITLE
Handle null selectables when exporting hover data

### DIFF
--- a/src/BetterInfoCards/Export/ExportSelectToolData.cs
+++ b/src/BetterInfoCards/Export/ExportSelectToolData.cs
@@ -130,7 +130,16 @@ namespace BetterInfoCards
             private static void ExportSelectableFromList(List<KSelectable> selectables) => ExportSelectable(selectables.LastOrDefault());
             private static void ExportSelectable(KSelectable selectable) => curSelectable = selectable;
             private static void Export(string name, object data) => curTextInfo = (name, data);
-            private static void ExportGO(string name) => Export(name, curSelectable.gameObject);
+            private static void ExportGO(string name)
+            {
+                if (curSelectable == null)
+                {
+                    Debug.LogWarning($"[BetterInfoCards] Skipping export for '{name}' because there is no active selectable.");
+                    return;
+                }
+
+                Export(name, curSelectable.gameObject);
+            }
             private static void ExportStatus(StatusItemGroup.Entry entry) => Export(entry.item.Id, entry.data);
         }
     }

--- a/tests/BetterInfoCards.Tests/ExportSelectToolDataTests.cs
+++ b/tests/BetterInfoCards.Tests/ExportSelectToolDataTests.cs
@@ -1,0 +1,41 @@
+using System.Reflection;
+using BetterInfoCards;
+using Xunit;
+
+namespace BetterInfoCards.Tests
+{
+    public sealed class ExportSelectToolDataTests
+    {
+        [Fact]
+        public void ExportGo_IgnoresMissingSelectable()
+        {
+            _ = ExportSelectToolData.ConsumeSelectable();
+            _ = ExportSelectToolData.ConsumeTextInfo();
+
+            var patchType = typeof(ExportSelectToolData).GetNestedType(
+                "GetSelectInfo_Patch",
+                BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(patchType);
+
+            var exportSelectable = patchType!.GetMethod(
+                "ExportSelectable",
+                BindingFlags.Static | BindingFlags.NonPublic);
+            var exportGo = patchType.GetMethod(
+                "ExportGO",
+                BindingFlags.Static | BindingFlags.NonPublic);
+
+            Assert.NotNull(exportSelectable);
+            Assert.NotNull(exportGo);
+
+            exportSelectable!.Invoke(null, new object?[] { null });
+
+            var exception = Record.Exception(() => exportGo!.Invoke(null, new object?[] { "test" }));
+
+            Assert.Null(exception);
+
+            var (id, data) = ExportSelectToolData.ConsumeTextInfo();
+            Assert.Equal(string.Empty, id);
+            Assert.Null(data);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- guard ExportSelectToolData.ExportGO against missing selectables and log when no export is possible
- add a regression test that exercises ExportGO with an empty selectable to ensure no exception is thrown

## Testing
- `dotnet test tests/BetterInfoCards.Tests/BetterInfoCards.Tests.csproj` *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de34ac38e883299e3c89c9c26e2ed3