### PR TITLE
Scope ApplyButtonsToPrefabs patch to SuppressNotifications

### DIFF
--- a/src/SuppressNotifications/UI/ApplyButtonsToPrefabs.cs
+++ b/src/SuppressNotifications/UI/ApplyButtonsToPrefabs.cs
@@ -2,7 +2,7 @@
 using HarmonyLib;
 using SuppressNotifications;
 
-namespace BetterLogicOverlay.LogicSettingDisplay
+namespace SuppressNotifications.UI
 {
     [HarmonyPatch(typeof(Assets), nameof(Assets.CreatePrefabs))]
     class ApplySettingsToDefs


### PR DESCRIPTION
## Summary
- update ApplyButtonsToPrefabs to live under the SuppressNotifications.UI namespace so the Harmony patch stays within the mod scope

## Testing
- not run (requires ONI assemblies not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68de3b6c24cc8329ad4815c0e4550271