### PR TITLE
Add managed folder override hooks

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,6 +5,14 @@
   <Import Project="Directory.Build.props.default" />
   <Import Condition=" Exists('Directory.Build.props.user') " Project="Directory.Build.props.user" />
 
+  <!--Allow environment or MSBuild overrides for non-standard installs.-->
+  <PropertyGroup Condition="'$(ONI_GAME_MANAGED)' != '' and Exists('$(ONI_GAME_MANAGED)')">
+    <GameFolder>$(ONI_GAME_MANAGED)</GameFolder>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(ONIGameManaged)' != '' and Exists('$(ONIGameManaged)')">
+    <GameFolder>$(ONIGameManaged)</GameFolder>
+  </PropertyGroup>
+
   <!--Base Settings-->
   <PropertyGroup>
     <TargetFramework>net471</TargetFramework>

--- a/src/README.md
+++ b/src/README.md
@@ -9,6 +9,19 @@ Compiling this solution is fairly simple.  If you run into issues, feel free to 
   - In the `Solution Items` folder, add a new `.xml` file named `Directory.Build.props.user`.
   - Copy the contents of `.default` to `.user`.
   - Edit any properties specific to your environment in `.user`.
+- You can also override the managed game folder without creating a `.user` file by setting one of the built-in overrides:
+  - Set the `ONI_GAME_MANAGED` environment variable to the full path of `OxygenNotIncluded_Data\Managed`.
+  - Or provide the same path via the `ONIGameManaged` MSBuild property.
+  - Both overrides only apply when the supplied directory exists, otherwise the default Steam path is used.
+
+Example (Windows, alternate drive):
+
+```cmd
+set ONI_GAME_MANAGED=D:\SteamLibrary\steamapps\common\OxygenNotIncluded\OxygenNotIncluded_Data\Managed
+msbuild /p:ONIGameManaged="%ONI_GAME_MANAGED%" oniMods.sln
+```
+
+Set the variable before starting Visual Studio or your terminal build to ensure the custom location is respected.
 - Rebuild the solution.
   - Automatically pulls in required packages through nuget.
   - Creates publicized assemblies.


### PR DESCRIPTION
## Summary
- allow Directory.Build.props to respect the ONI_GAME_MANAGED environment variable or ONIGameManaged property when the directory exists
- document the new override workflow and provide an example configuration in src/README.md

## Testing
- `dotnet build src/AzeLib/AzeLib.csproj` *(fails: dotnet CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de788217c883299b3f31250895ed6e