### PR TITLE
Fix Directory.Build.props IMGUI reference

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -57,7 +57,7 @@
     <Reference Include="UnityEngine" HintPath="$(GameFolder)/UnityEngine.dll" />
     <Reference Include="UnityEngine.CoreModule" HintPath="$(GameFolder)/UnityEngine.CoreModule.dll" />
     <Reference Include="UnityEngine.ImageConversionModule" HintPath="$(GameFolder)/UnityEngine.ImageConversionModule.dll" />
-    <Reference Include="UnityEngine.ImageConversionModule" HintPath="$(GameFolder)/UnityEngine.IMGUIModule.dll" />
+    <Reference Include="UnityEngine.IMGUIModule" HintPath="$(GameFolder)/UnityEngine.IMGUIModule.dll" />
     <Reference Include="UnityEngine.InputLegacyModule" HintPath="$(GameFolder)/UnityEngine.InputLegacyModule.dll" />
     <Reference Include="UnityEngine.TextRenderingModule" HintPath="$(GameFolder)/UnityEngine.TextRenderingModule.dll" />
     <Reference Include="UnityEngine.UI" HintPath="$(GameFolder)/UnityEngine.UI.dll" />


### PR DESCRIPTION
## Summary
- point the IMGUI reference in Directory.Build.props to UnityEngine.IMGUIModule
- ensure only one ImageConversion reference remains in the shared project props

## Testing
- ⚠️ `dotnet build src/BuildMenuSearchHotkey/BuildMenuSearchHotkey.csproj` *(fails: dotnet CLI not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de797f61708329afe45ff191fb7d45