### PR TITLE
Avoid direct HoverTextDrawer pool dependency in InfoCardWidgets

### DIFF
--- a/src/BetterInfoCards/Export/ExportWidgets.cs
+++ b/src/BetterInfoCards/Export/ExportWidgets.cs
@@ -68,8 +68,7 @@ namespace BetterInfoCards.Export
                 var entryType = __result.GetType();
                 if (entryType.Name == "Entry")
                 {
-                    // Try to cast __result to the expected type using dynamic
-                    curICWidgets.AddWidget((dynamic)__result, prefab);
+                    curICWidgets.AddWidget(__result, prefab);
                 }
             }
         }

--- a/src/BetterInfoCards/Info/InfoCardWidgets.cs
+++ b/src/BetterInfoCards/Info/InfoCardWidgets.cs
@@ -1,55 +1,108 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
 using UnityEngine;
-using Entry = HoverTextDrawer.Pool<UnityEngine.MonoBehaviour>.Entry;
 
 namespace BetterInfoCards
 {
     public class InfoCardWidgets
     {
-        public List<Entry> widgets = new();
-        public Entry shadowBar;
-        public Entry selectBorder;
+        private static readonly Dictionary<Type, Func<object, RectTransform>> rectAccessors = new();
+        private static readonly object rectAccessorLock = new();
+
+        public List<RectTransform> widgets = new();
+        public RectTransform shadowBar;
+        public RectTransform selectBorder;
         public Vector2 offset = new();
 
-        public float YMax => shadowBar.rect.anchoredPosition.y;
+        public float YMax => shadowBar != null ? shadowBar.anchoredPosition.y : 0f;
         public float YMin => YMax - Height;
-        public float Width => shadowBar.rect.rect.width;
-        public float Height => shadowBar.rect.rect.height;
+        public float Width => shadowBar != null ? shadowBar.rect.width : 0f;
+        public float Height => shadowBar != null ? shadowBar.rect.height : 0f;
 
-        public void AddWidget(Entry entry, GameObject prefab)
+        public void AddWidget(object entry, GameObject prefab)
         {
+            if (entry == null)
+                return;
+
+            var rect = ExtractRect(entry);
+            if (rect == null)
+                return;
+
             var skin = HoverTextScreen.Instance.drawer.skin;
 
             if (prefab == skin.shadowBarWidget.gameObject)
-                shadowBar = entry;
+                shadowBar = rect;
             else if (prefab == skin.selectBorderWidget.gameObject)
-                selectBorder = entry;
+                selectBorder = rect;
             else
-                widgets.Add(entry);
+                widgets.Add(rect);
         }
 
         public void Translate(float x)
         {
             var shift = new Vector2(x, offset.y);
 
-            shadowBar.rect.anchoredPosition += shift;
+            if (shadowBar != null)
+                shadowBar.anchoredPosition += shift;
 
-            if (selectBorder.rect != null)
-                selectBorder.rect.anchoredPosition += shift;
+            if (selectBorder != null)
+                selectBorder.anchoredPosition += shift;
 
             foreach (var widget in widgets)
-                widget.rect.anchoredPosition += shift;
+                if (widget != null)
+                    widget.anchoredPosition += shift;
         }
 
         public void SetWidth(float width)
         {
+            if (shadowBar == null)
+                return;
+
             // Modifying existing SBs triggers rebuilds somewhere and has a major impact on performance.
             // Genius idea from Peter to just add new ones to fill the gap.
-            var newSB = InterceptHoverDrawer.drawerInstance.shadowBars.Draw(shadowBar.rect.anchoredPosition + new Vector2(shadowBar.rect.sizeDelta.x, 0f));
-            newSB.rect.sizeDelta = new Vector2(width - shadowBar.rect.sizeDelta.x, shadowBar.rect.sizeDelta.y);
+            Vector2 newShadowBarPosition = shadowBar.anchoredPosition + new Vector2(shadowBar.sizeDelta.x, 0f);
+            dynamic drawer = InterceptHoverDrawer.drawerInstance;
+            var newShadowBar = ExtractRect(drawer.shadowBars.Draw(newShadowBarPosition));
+            if (newShadowBar != null)
+                newShadowBar.sizeDelta = new Vector2(width - shadowBar.sizeDelta.x, shadowBar.sizeDelta.y);
 
-            if (selectBorder.rect != null)
-                selectBorder.rect.sizeDelta = new Vector2(width + 2f, selectBorder.rect.sizeDelta.y);
+            if (selectBorder != null)
+                selectBorder.sizeDelta = new Vector2(width + 2f, selectBorder.sizeDelta.y);
+        }
+
+        private static RectTransform ExtractRect(object entry)
+        {
+            var type = entry.GetType();
+
+            if (!rectAccessors.TryGetValue(type, out var accessor))
+            {
+                lock (rectAccessorLock)
+                {
+                    if (!rectAccessors.TryGetValue(type, out accessor))
+                    {
+                        accessor = CreateAccessor(type);
+                        rectAccessors[type] = accessor;
+                    }
+                }
+            }
+
+            return accessor(entry);
+        }
+
+        private static Func<object, RectTransform> CreateAccessor(Type type)
+        {
+            const BindingFlags flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+
+            var rectField = type.GetField("rect", flags);
+            if (rectField != null && typeof(RectTransform).IsAssignableFrom(rectField.FieldType))
+                return entry => (RectTransform)rectField.GetValue(entry);
+
+            var rectProperty = type.GetProperty("rect", flags);
+            if (rectProperty != null && typeof(RectTransform).IsAssignableFrom(rectProperty.PropertyType))
+                return entry => (RectTransform)rectProperty.GetValue(entry);
+
+            return _ => null;
         }
     }
 }


### PR DESCRIPTION
## Summary
- extract and cache RectTransform references from widget pool entries so InfoCardWidgets only tracks transforms
- call HoverTextDrawer shadow bar draws through dynamic access to remove compile-time dependencies on private pool types

## Testing
- dotnet build src/BetterInfoCards/BetterInfoCards.csproj *(fails: `dotnet` not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfdcf09d2c8329b51d504b945d2a1a