### PR TITLE
Update BetterInfoCards overlay patch for new MiscStatusItems init

### DIFF
--- a/src/BetterInfoCards/Tweaks/ChangeStatusItemOverlays.cs
+++ b/src/BetterInfoCards/Tweaks/ChangeStatusItemOverlays.cs
@@ -1,11 +1,89 @@
-﻿using Database;
+using System;
+using System.Reflection;
+using Database;
 using HarmonyLib;
 
 namespace BetterInfoCards
 {
-    [HarmonyPatch(typeof(MiscStatusItems), nameof(MiscStatusItems.CreateStatusItems))]
+    [HarmonyPatch(typeof(MiscStatusItems))]
     class ChangeStatusItemOverlays
     {
+        static MethodBase TargetMethod()
+        {
+            var type = typeof(MiscStatusItems);
+
+            foreach (var name in new[]
+            {
+                "CreateStatusItems",
+                "PopulateStatusItems",
+                "InitializeStatusItems",
+                "InitStatusItems",
+                "ConfigureStatusItems"
+            })
+            {
+                var method = AccessTools.DeclaredMethod(type, name);
+                if (method != null)
+                    return method;
+            }
+
+            var oreTempField = AccessTools.DeclaredField(type, nameof(MiscStatusItems.OreTemp));
+            var unreachableField = AccessTools.DeclaredField(type, nameof(MiscStatusItems.PickupableUnreachable));
+            var categoryField = AccessTools.DeclaredField(type, nameof(MiscStatusItems.ElementalCategory));
+
+            if (oreTempField == null || unreachableField == null || categoryField == null)
+                return null;
+
+            var oreTempToken = oreTempField.MetadataToken;
+            var unreachableToken = unreachableField.MetadataToken;
+            var categoryToken = categoryField.MetadataToken;
+
+            foreach (var method in AccessTools.GetDeclaredMethods(type))
+            {
+                if (method.IsAbstract || method.IsConstructor)
+                    continue;
+
+                var body = method.GetMethodBody();
+                if (body == null)
+                    continue;
+
+                var il = body.GetILAsByteArray();
+                if (il == null || il.Length == 0)
+                    continue;
+
+                if (ContainsToken(il, oreTempToken) &&
+                    ContainsToken(il, unreachableToken) &&
+                    ContainsToken(il, categoryToken))
+                    return method;
+            }
+
+            return null;
+        }
+
+        static bool ContainsToken(byte[] il, int token)
+        {
+            if (il == null || il.Length < 4)
+                return false;
+
+            var tokenBytes = BitConverter.GetBytes(token);
+            for (var i = 0; i <= il.Length - tokenBytes.Length; i++)
+            {
+                var matches = true;
+                for (var j = 0; j < tokenBytes.Length; j++)
+                {
+                    if (il[i + j] != tokenBytes[j])
+                    {
+                        matches = false;
+                        break;
+                    }
+                }
+
+                if (matches)
+                    return true;
+            }
+
+            return false;
+        }
+
         static void Postfix(MiscStatusItems __instance)
         {
             // Prevents the duplicate temp status from being drawn in the temp overlay.


### PR DESCRIPTION
## Summary
- retarget the ChangeStatusItemOverlays Harmony patch to whichever MiscStatusItems initializer populates OreTemp, PickupableUnreachable, and ElementalCategory
- add IL-token based fallback detection so the overlay suppression still applies even if the initializer is renamed again

## Testing
- msbuild src/oniMods.sln /t:Build /p:Configuration=Release *(fails: msbuild not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfde1895848329bf9ecf02ffd3eed0