### PR TITLE
Use hover drawer skin for info card counts

### DIFF
--- a/src/BetterInfoCards/Info/InfoCard.cs
+++ b/src/BetterInfoCards/Info/InfoCard.cs
@@ -38,8 +38,12 @@ namespace BetterInfoCards
                 // Getting the style like this is not ideal since it could potentially be different from the title's.
                 // It does not appear to be an issue under current game conditions though.
                 var ti = TextInfo.Create(string.Empty, " #" + (++visCardIndex), null);
-                var drawCount = new DrawActions.Text().Set(ti, SelectTool.Instance.hoverTextConfiguration.Styles_Title.Standard, Color.white, false);
-                drawActions.Insert(++titleDrawer.drawIndex, drawCount);
+                var skin = InterceptHoverDrawer.drawerInstance?.skin ?? HoverTextScreen.Instance?.drawer?.skin;
+                if (skin != null)
+                {
+                    var drawCount = new DrawActions.Text().Set(ti, skin.Styles_Title.Standard, Color.white, false);
+                    drawActions.Insert(++titleDrawer.drawIndex, drawCount);
+                }
             }
 
             InterceptHoverDrawer.drawerInstance.BeginShadowBar(isSelected);


### PR DESCRIPTION
## Summary
- update the info card count text style to pull from the active hover drawer skin so it matches the intercepted hover text titles
- handle missing drawer skins gracefully when multiple cards are drawn

## Testing
- dotnet build src/BetterInfoCards/BetterInfoCards.csproj *(fails: `dotnet` is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfe88d357c8329ba9f4aea2f18b343