### PR TITLE
Fix BetterInfoCards reflection for private GetObjectUnderCursor

### DIFF
--- a/src/BetterInfoCards/Process/ModifyHits.cs
+++ b/src/BetterInfoCards/Process/ModifyHits.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -15,7 +16,12 @@ namespace BetterInfoCards
         {
             private static KSelectable priorSelected;
 
-            static MethodBase TargetMethod() => AccessTools.Method(typeof(InterfaceTool), nameof(InterfaceTool.GetObjectUnderCursor)).MakeGenericMethod(typeof(KSelectable));
+            static MethodBase TargetMethod() => AccessTools.Method(
+                typeof(InterfaceTool),
+                "GetObjectUnderCursor",
+                null,
+                new[] { typeof(bool), typeof(Func<,>), typeof(Component) })
+                .MakeGenericMethod(typeof(KSelectable));
 
             static void Postfix(bool cycleSelection, ref KSelectable __result, List<InterfaceTool.Intersection> ___intersections)
             {


### PR DESCRIPTION
## Summary
- update the BetterInfoCards ModifyHits patch to reference the private InterfaceTool.GetObjectUnderCursor overload using an explicit signature
- add the System namespace import so the reflection call can declare the open generic Func parameter

## Testing
- ⚠️ `dotnet build src/oniMods.sln` *(fails: `dotnet` is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfe93cfef48329823ad23103831db2