### PR TITLE
Use Delegate.Combine when registering ResetPool reset callback

### DIFF
--- a/src/BetterInfoCards/Util/ResetPool.cs
+++ b/src/BetterInfoCards/Util/ResetPool.cs
@@ -42,7 +42,7 @@ namespace BetterInfoCards
             this.trimSlack = trimSlack;
             idleTrimThreshold = ToStopwatchTicks(idleTrimAge ?? TimeSpan.FromSeconds(30));
 
-            resetOn += Reset;
+            resetOn = (Action)Delegate.Combine(resetOn, Reset);
         }
 
         public ResetPool(ref System.Action onBeginDrawing)


### PR DESCRIPTION
## Summary
- replace the ResetPool constructor's `+=` registration with `Delegate.Combine` to ensure delegate wiring compiles cleanly

## Testing
- dotnet build src/BetterInfoCards/BetterInfoCards.csproj *(fails: `dotnet` command is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e009b7d1f483298789d5d4d7f8f4a3