### PR TITLE
Preserve info card title styles for count suffix

### DIFF
--- a/src/BetterInfoCards/Info/DrawActions.cs
+++ b/src/BetterInfoCards/Info/DrawActions.cs
@@ -11,10 +11,12 @@ namespace BetterInfoCards
 
         public class Text : DrawActions
         {
-            TextInfo ti; 
+            TextInfo ti;
             TextStyleSetting style;
             Color color;
             bool overrideColor;
+
+            public TextStyleSetting Style => style;
 
             public Text Set(TextInfo ti, TextStyleSetting style, Color color, bool overrideColor)
             {


### PR DESCRIPTION
## Summary
- store the text style captured with the first title draw action so it can be reused
- expose the style from DrawActions.Text and reuse it when inserting the multi-card count suffix

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e00cf0076883299dec94974e813663