### PR TITLE
Fix ResetPool delegate subscription compilation issue

### DIFF
--- a/src/BetterInfoCards/Util/ResetPool.cs
+++ b/src/BetterInfoCards/Util/ResetPool.cs
@@ -42,7 +42,7 @@ namespace BetterInfoCards
             this.trimSlack = trimSlack;
             idleTrimThreshold = ToStopwatchTicks(idleTrimAge ?? TimeSpan.FromSeconds(30));
 
-            resetOn = (Action)Delegate.Combine(resetOn, Reset);
+            resetOn += Reset;
         }
 
         public ResetPool(ref System.Action onBeginDrawing)


### PR DESCRIPTION
## Summary
- update the ResetPool constructor to add the Reset handler with the `+=` operator so both operands are concrete `Action` instances for compilation

## Testing
- dotnet build src/oniMods.sln *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68e00db9e7448329b06c366aa0b336f9