### PR TITLE
Fix nullable annotations in CardTweaker

### DIFF
--- a/src/BetterInfoCards/Tweaks/CardTweaker.cs
+++ b/src/BetterInfoCards/Tweaks/CardTweaker.cs
@@ -97,9 +97,9 @@ namespace BetterInfoCards
 
         private static class DrawPositionAccessor
         {
-            private static readonly FieldInfo? currentPosField = AccessTools.Field(typeof(HoverTextDrawer), "currentPos");
-            private static readonly FieldInfo? drawStateField = AccessTools.Field(typeof(HoverTextDrawer), "drawState");
-            private static readonly FieldInfo? drawStateCurrentPositionField = drawStateField != null
+            private static readonly FieldInfo currentPosField = AccessTools.Field(typeof(HoverTextDrawer), "currentPos");
+            private static readonly FieldInfo drawStateField = AccessTools.Field(typeof(HoverTextDrawer), "drawState");
+            private static readonly FieldInfo drawStateCurrentPositionField = drawStateField != null
                 ? AccessTools.Field(drawStateField.FieldType, "currentPosition")
                 : null;
 


### PR DESCRIPTION
## Summary
- remove nullable FieldInfo annotations from the BetterInfoCards DrawPositionAccessor
- rely on existing runtime null checks for safety

## Testing
- dotnet build *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e00e5b7b9c832992eb8460b048e945