### PR TITLE
Use action cast when combining reset delegate

### DIFF
--- a/src/BetterInfoCards/Util/ResetPool.cs
+++ b/src/BetterInfoCards/Util/ResetPool.cs
@@ -42,7 +42,7 @@ namespace BetterInfoCards
             this.trimSlack = trimSlack;
             idleTrimThreshold = ToStopwatchTicks(idleTrimAge ?? TimeSpan.FromSeconds(30));
 
-            resetOn = (Action)Delegate.Combine(resetOn, new Action(Reset));
+            resetOn = (Action)Delegate.Combine(resetOn, (Action)Reset);
         }
 
         public ResetPool(ref System.Action onBeginDrawing)


### PR DESCRIPTION
## Summary
- cast Reset directly to Action when combining delegates so both arguments share the same delegate type

## Testing
- dotnet build src/oniMods.sln *(fails: `dotnet` is not installed in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0111f4ea48329b96bd076f4201a55