### PR TITLE
Fix ResetPool delegate hookup

### DIFF
--- a/src/BetterInfoCards/Util/ResetPool.cs
+++ b/src/BetterInfoCards/Util/ResetPool.cs
@@ -42,7 +42,8 @@ namespace BetterInfoCards
             this.trimSlack = trimSlack;
             idleTrimThreshold = ToStopwatchTicks(idleTrimAge ?? TimeSpan.FromSeconds(30));
 
-            resetOn = (Action)Delegate.Combine(resetOn, (Action)Reset);
+            Action resetHandler = Reset;
+            resetOn = (Action)Delegate.Combine(resetOn, resetHandler);
         }
 
         public ResetPool(ref System.Action onBeginDrawing)


### PR DESCRIPTION
## Summary
- capture the ResetPool Reset handler in a local variable before combining with an existing delegate
- use the cached delegate when invoking Delegate.Combine to avoid invalid casts under the ONI toolchain

## Testing
- `dotnet build src/oniMods.sln` *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0132293f4832980f15efb4fc27b43