### PR TITLE
Fix ResetPool delegate type

### DIFF
--- a/src/BetterInfoCards/Util/ResetPool.cs
+++ b/src/BetterInfoCards/Util/ResetPool.cs
@@ -24,7 +24,7 @@ namespace BetterInfoCards
         private long lastResetTimestamp;
 
         public ResetPool(
-            ref Action resetOn,
+            ref System.Action resetOn,
             int lowUsageCyclesBeforeTrim = 3,
             double lowUsageRatio = 0.5,
             double trimSlack = 0.25,
@@ -42,8 +42,8 @@ namespace BetterInfoCards
             this.trimSlack = trimSlack;
             idleTrimThreshold = ToStopwatchTicks(idleTrimAge ?? TimeSpan.FromSeconds(30));
 
-            Action resetHandler = Reset;
-            resetOn = (Action)Delegate.Combine(resetOn, resetHandler);
+            System.Action resetHandler = Reset;
+            resetOn = (System.Action)Delegate.Combine(resetOn, resetHandler);
         }
 
         public ResetPool(ref System.Action onBeginDrawing)


### PR DESCRIPTION
## Summary
- use fully-qualified System.Action for ResetPool's reset hook and handler
- cast the combined delegate back to System.Action to preserve type safety

## Testing
- `dotnet build oniMods.sln` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e014cd35fc83298b9d633d3a1ea708