### PR TITLE
Handle U56 generic arity for BetterInfoCards hits

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -35,3 +35,8 @@
 ## 2025-10-08 - ResetPool delegate wiring
 - Confirmed the delegate wiring change builds under the ONI toolchain in principle, but the container image still lacks a .NET runtime (`dotnet` is unavailable), so a full `oniMods.sln` rebuild could not be executed here.
 - Maintainers should rerun `dotnet build src/oniMods.sln` on a workstation with the ONI assemblies installed to verify end-to-end.
+
+## 2025-10-09 - BetterInfoCards cursor hit patch compatibility
+- Updated the reflection used by `ModifyHits` to tolerate the additional generic argument introduced in U56 so the mod no longer throws `Incorrect length` at load.
+- Attempted to rebuild via `dotnet build src/oniMods.sln`, but the container image still lacks a .NET runtime, so compilation could not be performed here.
+- Maintainers should rebuild on a workstation with the ONI-managed assemblies to validate Harmony loads cleanly in-game.


### PR DESCRIPTION
## Summary
- make the Better Info Cards hit patch reflectively bind all supported generic arities for InterfaceTool.GetObjectUnderCursor
- document the outstanding requirement to rebuild with a full ONI toolchain in NOTES.md

## Testing
- `dotnet build src/oniMods.sln` *(fails: dotnet is unavailable in the container image)*

------
https://chatgpt.com/codex/tasks/task_e_68e0231bd43c832988669c9eabdce1ad