### PR TITLE
Handle InterfaceTool generic arity change

### DIFF
--- a/src/BetterInfoCards/Process/ModifyHits.cs
+++ b/src/BetterInfoCards/Process/ModifyHits.cs
@@ -35,11 +35,22 @@ namespace BetterInfoCards
 
                 var genericArguments = getObjectMethod.GetGenericArguments();
 
-                if (genericArguments.Length == 1)
-                    return getObjectMethod.MakeGenericMethod(typeof(KSelectable));
+                // U56 introduces a third generic argument: InterfaceTool.IntersectionCandidate (ordered after Intersection).
+                Type[] genericTypes = genericArguments.Length switch
+                {
+                    1 => new[] { typeof(KSelectable) },
+                    2 => new[] { typeof(KSelectable), typeof(InterfaceTool.Intersection) },
+                    3 => new[]
+                    {
+                        typeof(KSelectable),
+                        typeof(InterfaceTool.Intersection),
+                        typeof(InterfaceTool.IntersectionCandidate)
+                    },
+                    _ => null
+                };
 
-                if (genericArguments.Length == 2)
-                    return getObjectMethod.MakeGenericMethod(typeof(KSelectable), typeof(InterfaceTool.Intersection));
+                if (genericTypes != null)
+                    return getObjectMethod.MakeGenericMethod(genericTypes);
 
                 Debug.LogWarning($"[BetterInfoCards] Unexpected generic arity ({genericArguments.Length}) for {nameof(InterfaceTool)}.{methodName}; skipping patch.");
                 return null;


### PR DESCRIPTION
## Summary
- update the Better Info Cards hook to handle the new three-argument generic form of InterfaceTool.GetObjectUnderCursor introduced in U56
- keep the existing one- and two-generic argument fallbacks and continue logging when the arity is unexpected

## Testing
- not run (dotnet/msbuild tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e02b01f5708329b3d547644cbf3c2c