### PR TITLE
Update ModifyHits namespace to BetterInfoCards.Process

### DIFF
--- a/src/BetterInfoCards/Process/ModifyHits.cs
+++ b/src/BetterInfoCards/Process/ModifyHits.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Reflection;
 using UnityEngine;
 
-namespace BetterInfoCards
+namespace BetterInfoCards.Process
 {
     public static class ModifyHits
     {

--- a/src/BetterInfoCards/Process/ProcessHoverInfo.cs
+++ b/src/BetterInfoCards/Process/ProcessHoverInfo.cs
@@ -1,4 +1,5 @@
-﻿using BetterInfoCards.Export;
+using BetterInfoCards.Export;
+using BetterInfoCards.Process;
 using HarmonyLib;
 
 namespace BetterInfoCards


### PR DESCRIPTION
## Summary
- move ModifyHits into the BetterInfoCards.Process namespace
- import the new namespace in ProcessHoverInfo so ModifyHits remains accessible

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0380e3f9883298384b9388f1058d7