### PR TITLE
Expand explicit type usage in ModifyHits

### DIFF
--- a/src/BetterInfoCards/Process/ModifyHits.cs
+++ b/src/BetterInfoCards/Process/ModifyHits.cs
@@ -9,7 +9,7 @@ namespace BetterInfoCards.Process
 {
     public static class ModifyHits
     {
-        private static List<DisplayCard> displayCards = new();
+        private static List<DisplayCard> displayCards = new List<DisplayCard>();
 
         [HarmonyPatch]
         private static class ChangeHits_Patch


### PR DESCRIPTION
## Summary
- replace the target-typed List initializer in ModifyHits with an explicit type to support older language versions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e039ab25548329a1bfad3274e6a745