### PR TITLE
Fix fallback reflection lookup for InterfaceTool

### DIFF
--- a/src/BetterInfoCards/Process/ModifyHits.cs
+++ b/src/BetterInfoCards/Process/ModifyHits.cs
@@ -22,7 +22,7 @@ namespace BetterInfoCards.Process
                 var parameterTypes = new[] { typeof(bool), typeof(Func<,>), typeof(Component) };
 
                 var getObjectMethod = AccessTools.DeclaredMethod(typeof(InterfaceTool), methodName, parameterTypes)
-                    ?? AccessTools.Method(typeof(InterfaceTool), methodName, null, parameterTypes);
+                    ?? AccessTools.Method(typeof(InterfaceTool), methodName, parameterTypes);
 
                 if (getObjectMethod == null)
                 {


### PR DESCRIPTION
## Summary
- correct the fallback AccessTools.Method call so the InterfaceTool lookup uses the parameter list instead of the generics slot

## Testing
- dotnet build oniMods.sln *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68e03eb91ca48329aa28d78c3304f25e