### PR TITLE
Use declared InterfaceTool methods for Harmony lookup

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -38,5 +38,6 @@
 
 ## 2025-10-09 - BetterInfoCards cursor hit patch compatibility
 - Updated the reflection used by `ModifyHits` to tolerate the additional generic argument introduced in U56 so the mod no longer throws `Incorrect length` at load.
+- Replaced the `AccessTools.AllMethods` lookup with `AccessTools.GetDeclaredMethods` so Harmony 2.3 continues to locate `InterfaceTool.GetObjectUnderCursor` without relying on removed APIs.
 - Attempted to rebuild via `dotnet build src/oniMods.sln`, but the container image still lacks a .NET runtime, so compilation could not be performed here.
 - Maintainers should rebuild on a workstation with the ONI-managed assemblies to validate Harmony loads cleanly in-game.

--- a/src/BetterInfoCards/Process/ModifyHits.cs
+++ b/src/BetterInfoCards/Process/ModifyHits.cs
@@ -19,7 +19,7 @@ namespace BetterInfoCards.Process
             static MethodBase TargetMethod()
             {
                 const string methodName = "GetObjectUnderCursor";
-                var getObjectMethod = AccessTools.AllMethods(typeof(InterfaceTool))
+                var getObjectMethod = AccessTools.GetDeclaredMethods(typeof(InterfaceTool))
                     .FirstOrDefault(method => method.Name == methodName && MatchesGetObjectUnderCursorSignature(method));
 
                 if (getObjectMethod == null)


### PR DESCRIPTION
## Summary
- replace the deprecated AccessTools.AllMethods lookup in ModifyHits with AccessTools.GetDeclaredMethods so Harmony 2.3 can still find GetObjectUnderCursor
- document the change and the missing dotnet build tooling in NOTES.md

## Testing
- dotnet build src/oniMods.sln *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68e0441eb9f4832991c021bd665aad4f