### PR TITLE
Add configurable info card background tint

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -45,3 +45,7 @@
 ## 2025-10-10 - BetterInfoCards cursor signature update
 - Relaxed the `ModifyHits` signature guard and added a bool-first fallback so Harmony locates the updated `InterfaceTool.GetObjectUnderCursor` overload even when U56 adds extra optional parameters.
 - Static inspection only; rebuilding still requires the ONI assemblies and a local .NET runtime, both unavailable in this container.
+
+## 2025-10-11 - BetterInfoCards shadow bar tint option
+- Added configurable RGB sliders for the info card shadow bar and ensured stretched bars reuse the selected tint.
+- Unable to rebuild `BetterInfoCards` here because the container still lacks the ONI-managed assemblies and `dotnet`; maintainers should run `dotnet build src/oniMods.sln` locally after syncing the new option values.

--- a/src/BetterInfoCards/Info/InfoCardWidgets.cs
+++ b/src/BetterInfoCards/Info/InfoCardWidgets.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using UnityEngine;
+using UnityEngine.UI;
 
 namespace BetterInfoCards
 {
@@ -95,7 +96,12 @@ namespace BetterInfoCards
 
             var newShadowBar = ExtractRect(shadowBarsDrawMethod.Invoke(shadowBars, new object[] { newShadowBarPosition }));
             if (newShadowBar != null)
+            {
                 newShadowBar.sizeDelta = new Vector2(width - shadowBar.sizeDelta.x, shadowBar.sizeDelta.y);
+                var image = newShadowBar.GetComponent<Image>();
+                if (image != null)
+                    image.color = CardTweaker.GetShadowBarColor();
+            }
 
             if (selectBorder != null)
                 selectBorder.sizeDelta = new Vector2(width + 2f, selectBorder.sizeDelta.y);

--- a/src/BetterInfoCards/Tweaks/CardTweaker.cs
+++ b/src/BetterInfoCards/Tweaks/CardTweaker.cs
@@ -18,15 +18,13 @@ namespace BetterInfoCards
         {
             // It is unclear where this magic number "+2" came from.
             private static readonly Vector2 border = new(Options.Opts.InfoCardSize.YPadding + 2, Options.Opts.InfoCardSize.YPadding);
-            private static readonly float opacity = Options.Opts.InfoCardOpacity / 100f;
 
             static void Prefix(ref HoverTextDrawer.Skin skin)
             {
                 if (ShouldTweak)
                     skin.shadowBarBorder = border;
 
-                var c = skin.shadowBarWidget.color;
-                skin.shadowBarWidget.color = new Color(c.r, c.g, c.b, opacity);
+                skin.shadowBarWidget.color = GetShadowBarColor();
             }
         }
 
@@ -93,6 +91,15 @@ namespace BetterInfoCards
             static bool Prepare() => ShouldTweak;
 
             static void Prefix(ref int image_size) => image_size += iconSizeChange;
+        }
+
+        internal static Color GetShadowBarColor()
+        {
+            return new Color(
+                Options.Opts.InfoCardBackgroundRed / 255f,
+                Options.Opts.InfoCardBackgroundGreen / 255f,
+                Options.Opts.InfoCardBackgroundBlue / 255f,
+                Options.Opts.InfoCardOpacity / 100f);
         }
 
         private static class DrawPositionAccessor

--- a/src/BetterInfoCards/Util/Options.cs
+++ b/src/BetterInfoCards/Util/Options.cs
@@ -8,6 +8,9 @@ namespace BetterInfoCards
     public class Options : BaseOptions<Options>
     {
         [Option] [Limit(0, 100)] public int InfoCardOpacity { get; set; }
+        [Option] [Limit(0, 255)] public byte InfoCardBackgroundRed { get; set; }
+        [Option] [Limit(0, 255)] public byte InfoCardBackgroundGreen { get; set; }
+        [Option] [Limit(0, 255)] public byte InfoCardBackgroundBlue { get; set; }
         [Option] public bool HideElementCategories { get; set; }
         [Option] public bool UseBaseSelection { get; set; }
         [Option] public bool ForceFirstSelectionToHover { get; set; }
@@ -17,6 +20,9 @@ namespace BetterInfoCards
         public Options()
         {
             InfoCardOpacity = 80;
+            InfoCardBackgroundRed = 73;
+            InfoCardBackgroundGreen = 79;
+            InfoCardBackgroundBlue = 96;
             HideElementCategories = false;
             UseBaseSelection = false;
             ForceFirstSelectionToHover = true;

--- a/src/BetterInfoCards/Util/STRINGS.cs
+++ b/src/BetterInfoCards/Util/STRINGS.cs
@@ -10,6 +10,24 @@ namespace BetterInfoCards
             public static LocString TOOLTIP = "Opactiy of info card backgrounds.  (Base game = 90%)";
         }
 
+        public class INFOCARDBACKGROUNDRED
+        {
+            public static LocString NAME = "Background Tint - Red";
+            public static LocString TOOLTIP = "Red channel value for the info card background tint.";
+        }
+
+        public class INFOCARDBACKGROUNDGREEN
+        {
+            public static LocString NAME = "Background Tint - Green";
+            public static LocString TOOLTIP = "Green channel value for the info card background tint.";
+        }
+
+        public class INFOCARDBACKGROUNDBLUE
+        {
+            public static LocString NAME = "Background Tint - Blue";
+            public static LocString TOOLTIP = "Blue channel value for the info card background tint.";
+        }
+
         public class TEMPERATUREBANDWIDTH
         {
             public static LocString NAME = "Temperature Band Width";


### PR DESCRIPTION
## Summary
- add RGB sliders to the Better Info Cards options so players can tint the shadow bar background
- compose the hover card shadow bar color from the chosen RGB values plus the opacity slider
- recolor any extra shadow bars spawned when cards widen and document the work in NOTES.md

## Testing
- not run (dotnet and ONI assemblies are unavailable in the container environment)


------
https://chatgpt.com/codex/tasks/task_e_68e056372a3483298c5798699a4bf02c