### PR TITLE
Handle BetterInfoCards widget clones

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -53,3 +53,7 @@
 ## 2025-10-12 - BetterInfoCards shadow bar tint persistence
 - Ensured the prefab shadow bar and dynamically spawned extensions copy the configured tint to their `ColorStyleSetting` values so refreshes preserve the selected RGB.
 - Build and in-game validation remain blocked in this container due to missing ONI assemblies and the `dotnet` host; maintainers should rebuild via `dotnet build src/oniMods.sln` and confirm the slider-controlled tint persists in-game.
+
+## 2025-10-13 - BetterInfoCards widget clone matching
+- Relaxed the widget matching so `InfoCardWidgets` recognises hover drawer clones by comparing prefab names (sans `"(Clone)"`) and verifying the component layout/rect dimensions.
+- Unable to rebuild or verify the mod in-game here because the container lacks the ONI managed assemblies and a .NET runtime; maintainers should rebuild via `dotnet build src/oniMods.sln` and confirm stacked hover cards wrap correctly.

--- a/src/BetterInfoCards/Info/InfoCardWidgets.cs
+++ b/src/BetterInfoCards/Info/InfoCardWidgets.cs
@@ -40,12 +40,68 @@ namespace BetterInfoCards
 
             var skin = HoverTextScreen.Instance.drawer.skin;
 
-            if (prefab == skin.shadowBarWidget.gameObject)
+            if (MatchesWidgetPrefab(prefab, skin.shadowBarWidget?.gameObject))
                 shadowBar = rect;
-            else if (prefab == skin.selectBorderWidget.gameObject)
+            else if (MatchesWidgetPrefab(prefab, skin.selectBorderWidget?.gameObject))
                 selectBorder = rect;
             else
                 widgets.Add(rect);
+        }
+
+        private static bool MatchesWidgetPrefab(GameObject candidate, GameObject reference)
+        {
+            if (candidate == null || reference == null)
+                return false;
+
+            if (candidate == reference)
+                return true;
+
+            if (string.Equals(StripCloneSuffix(candidate.name), StripCloneSuffix(reference.name), StringComparison.Ordinal))
+                return true;
+
+            if (!HasMatchingComponents(candidate, reference))
+                return false;
+
+            var candidateRect = candidate.GetComponent<RectTransform>();
+            var referenceRect = reference.GetComponent<RectTransform>();
+
+            if (candidateRect == null || referenceRect == null)
+                return false;
+
+            return candidateRect.rect.size == referenceRect.rect.size;
+        }
+
+        private static string StripCloneSuffix(string name)
+        {
+            const string cloneSuffix = "(Clone)";
+
+            if (string.IsNullOrEmpty(name) || !name.EndsWith(cloneSuffix, StringComparison.Ordinal))
+                return name;
+
+            return name[..^cloneSuffix.Length];
+        }
+
+        private static bool HasMatchingComponents(GameObject candidate, GameObject reference)
+        {
+            var candidateComponents = candidate.GetComponents<Component>();
+            var referenceComponents = reference.GetComponents<Component>();
+
+            if (candidateComponents.Length != referenceComponents.Length)
+                return false;
+
+            for (int i = 0; i < candidateComponents.Length; i++)
+            {
+                var candidateComponent = candidateComponents[i];
+                var referenceComponent = referenceComponents[i];
+
+                if (candidateComponent == null || referenceComponent == null)
+                    return false;
+
+                if (candidateComponent.GetType() != referenceComponent.GetType())
+                    return false;
+            }
+
+            return true;
         }
 
         public void Translate(float x)


### PR DESCRIPTION
## Summary
- allow InfoCardWidgets to recognise hover drawer clones by stripping "(Clone)" suffixes and matching component layouts/rect sizes
- ensure the select border rect is captured even when the hover drawer provides a cloned widget
- note in NOTES.md that builds remain blocked in this container per the Maintainer Playbook

## Testing
- not run (missing ONI-managed assemblies and dotnet runtime in the container; see Maintainer Playbook)

------
https://chatgpt.com/codex/tasks/task_e_68e0c0c0d6148329a282b01196e8944e