### PR TITLE
Switch Better Info Cards background to color picker

### DIFF
--- a/src/BetterInfoCards/Tweaks/CardTweaker.cs
+++ b/src/BetterInfoCards/Tweaks/CardTweaker.cs
@@ -96,10 +96,12 @@ namespace BetterInfoCards
 
         internal static Color GetShadowBarColor()
         {
+            var background = Options.Opts.InfoCardBackgroundColor;
+
             return new Color(
-                Options.Opts.InfoCardBackgroundRed / 255f,
-                Options.Opts.InfoCardBackgroundGreen / 255f,
-                Options.Opts.InfoCardBackgroundBlue / 255f,
+                background.r / 255f,
+                background.g / 255f,
+                background.b / 255f,
                 Options.Opts.InfoCardOpacity / 100f);
         }
 

--- a/src/BetterInfoCards/Util/Options.cs
+++ b/src/BetterInfoCards/Util/Options.cs
@@ -1,6 +1,7 @@
-﻿using AzeLib;
+using AzeLib;
 using Newtonsoft.Json;
 using PeterHan.PLib.Options;
+using UnityEngine;
 
 namespace BetterInfoCards
 {
@@ -8,9 +9,16 @@ namespace BetterInfoCards
     public class Options : BaseOptions<Options>
     {
         [Option] [Limit(0, 100)] public int InfoCardOpacity { get; set; }
-        [Option] [Limit(0, 255)] public int InfoCardBackgroundRed { get; set; }
-        [Option] [Limit(0, 255)] public int InfoCardBackgroundGreen { get; set; }
-        [Option] [Limit(0, 255)] public int InfoCardBackgroundBlue { get; set; }
+        [Option] public Color32 InfoCardBackgroundColor { get; set; }
+
+        [JsonProperty("InfoCardBackgroundRed", NullValueHandling = NullValueHandling.Ignore)]
+        public int? LegacyInfoCardBackgroundRed { get; set; }
+
+        [JsonProperty("InfoCardBackgroundGreen", NullValueHandling = NullValueHandling.Ignore)]
+        public int? LegacyInfoCardBackgroundGreen { get; set; }
+
+        [JsonProperty("InfoCardBackgroundBlue", NullValueHandling = NullValueHandling.Ignore)]
+        public int? LegacyInfoCardBackgroundBlue { get; set; }
         [Option] public bool HideElementCategories { get; set; }
         [Option] public bool UseBaseSelection { get; set; }
         [Option] public bool ForceFirstSelectionToHover { get; set; }
@@ -20,9 +28,7 @@ namespace BetterInfoCards
         public Options()
         {
             InfoCardOpacity = 80;
-            InfoCardBackgroundRed = 73;
-            InfoCardBackgroundGreen = 79;
-            InfoCardBackgroundBlue = 96;
+            InfoCardBackgroundColor = new Color32(73, 79, 96, byte.MaxValue);
             HideElementCategories = false;
             UseBaseSelection = false;
             ForceFirstSelectionToHover = true;
@@ -46,6 +52,30 @@ namespace BetterInfoCards
             [Option] [Limit(0, 20)] public int LineSpacing { get; set; }
             [Option] [Limit(-10, 10)] public int IconSizeChange { get; set; }
             [Option] [Limit(1, 20)] public int YPadding { get; set; }
+        }
+
+        protected override bool ValidateSettings()
+        {
+            var valid = base.ValidateSettings();
+            var migrated = false;
+
+            if (LegacyInfoCardBackgroundRed.HasValue || LegacyInfoCardBackgroundGreen.HasValue || LegacyInfoCardBackgroundBlue.HasValue)
+            {
+                var red = (byte)Mathf.Clamp(LegacyInfoCardBackgroundRed ?? InfoCardBackgroundColor.r, 0, 255);
+                var green = (byte)Mathf.Clamp(LegacyInfoCardBackgroundGreen ?? InfoCardBackgroundColor.g, 0, 255);
+                var blue = (byte)Mathf.Clamp(LegacyInfoCardBackgroundBlue ?? InfoCardBackgroundColor.b, 0, 255);
+
+                var alpha = InfoCardBackgroundColor.a == 0 ? byte.MaxValue : InfoCardBackgroundColor.a;
+                InfoCardBackgroundColor = new Color32(red, green, blue, alpha);
+
+                LegacyInfoCardBackgroundRed = null;
+                LegacyInfoCardBackgroundGreen = null;
+                LegacyInfoCardBackgroundBlue = null;
+
+                migrated = true;
+            }
+
+            return valid && !migrated;
         }
     }
 }


### PR DESCRIPTION
## Summary
- consolidate Better Info Cards background tint settings into a single Color32 option and migrate legacy RGB values
- use the new color option when computing hover card shadow colors

## Testing
- not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e0c6de4a548329bad0c5cc3b495e29