### PR TITLE
Fix BetterInfoCards clone suffix trimming for .NET 4.7

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -57,3 +57,7 @@
 ## 2025-10-13 - BetterInfoCards widget clone matching
 - Relaxed the widget matching so `InfoCardWidgets` recognises hover drawer clones by comparing prefab names (sans `"(Clone)"`) and verifying the component layout/rect dimensions.
 - Unable to rebuild or verify the mod in-game here because the container lacks the ONI managed assemblies and a .NET runtime; maintainers should rebuild via `dotnet build src/oniMods.sln` and confirm stacked hover cards wrap correctly.
+
+## 2025-10-14 - BetterInfoCards .NET 4.7 compatibility cleanup
+- Replaced the C# 8 range expression in `StripCloneSuffix` with an explicit `Substring` call so the project compiles under the original .NET 4.7 target.
+- Attempted to rebuild via `dotnet build src/BetterInfoCards/BetterInfoCards.csproj`, but the container still lacks the .NET host (`dotnet` command is unavailable), so compilation must be verified on a workstation with the ONI assemblies and toolchain installed.

--- a/src/BetterInfoCards/Info/InfoCardWidgets.cs
+++ b/src/BetterInfoCards/Info/InfoCardWidgets.cs
@@ -78,7 +78,7 @@ namespace BetterInfoCards
             if (string.IsNullOrEmpty(name) || !name.EndsWith(cloneSuffix, StringComparison.Ordinal))
                 return name;
 
-            return name[..^cloneSuffix.Length];
+            return name.Substring(0, name.Length - cloneSuffix.Length);
         }
 
         private static bool HasMatchingComponents(GameObject candidate, GameObject reference)


### PR DESCRIPTION
## Summary
- replace the C# 8 range expression in `StripCloneSuffix` with a .NET 4.7-compatible `Substring`
- record the compatibility update and blocked rebuild in `NOTES.md`

## Testing
- `dotnet build src/BetterInfoCards/BetterInfoCards.csproj` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0c92b37e88329ad05197b245e9b82