### PR TITLE
Adjust color picker layout in Better Info Cards options

### DIFF
--- a/src/BetterInfoCards/Util/STRINGS.cs
+++ b/src/BetterInfoCards/Util/STRINGS.cs
@@ -10,6 +10,12 @@ namespace BetterInfoCards
             public static LocString TOOLTIP = "Opactiy of info card backgrounds.  (Base game = 90%)";
         }
 
+        public class INFOCARDBACKGROUNDCOLOR
+        {
+            public static LocString NAME = "Background Tint";
+            public static LocString TOOLTIP = "Select the color used for info card backgrounds.";
+        }
+
         public class INFOCARDBACKGROUNDRED
         {
             public static LocString NAME = "Background Tint - Red";


### PR DESCRIPTION
## Summary
- override the Better Info Cards options generation to supply a custom color picker entry
- constrain the realized color picker with a LayoutElement sized to the active screen width so it fits smaller displays
- add localized strings for the combined background tint option label and tooltip

## Testing
- not run (ONI/.NET toolchain is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e0cf3b28e08329b62ea75287007105