### PR TITLE
Normalize fallback widget prefabs

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -69,3 +69,7 @@
 ## 2025-10-16 - BetterInfoCards hover widget pool fallback
 - Added a fallback that patches `HoverTextDrawer.Pool<MonoBehaviour>.Draw` when the widget pool type cannot be located via reflection and cache the resolved entry type so `InfoCardWidgets` continues to capture the shadow bar metadata.
 - Static-only validation here; rebuilding `BetterInfoCards` requires the ONI-managed assemblies and a .NET host (`dotnet`) that are not present in the container, and in-game hover card wrapping must be verified on a workstation with the full toolchain.
+
+## 2025-10-17 - BetterInfoCards prefab normalization
+- Normalized the widget prefab reference captured by `ExportWidgets` so Harmony fallbacks that expose `Component` instances still map back to the underlying `GameObject`, keeping the `shadowBar` match logic intact.
+- Unable to rebuild `BetterInfoCards` or confirm the fallback captures non-null shadow bar rects in-game because the container lacks the ONI assemblies and runtime; maintainers should run `dotnet build src/oniMods.sln` and validate hover cards wrap across multiple columns locally.

--- a/src/BetterInfoCards/Export/ExportWidgets.cs
+++ b/src/BetterInfoCards/Export/ExportWidgets.cs
@@ -243,7 +243,11 @@ namespace BetterInfoCards.Export
         // This method will be used as a postfix for the Draw method via reflection.
         private static void GetWidget_Postfix(object __result, object ___prefab)
         {
-            if (__result == null || ___prefab is not GameObject prefab)
+            if (__result == null)
+                return;
+
+            var prefab = NormalizeToGameObject(___prefab);
+            if (prefab == null)
                 return;
 
             if (curICWidgets == null)
@@ -253,6 +257,19 @@ namespace BetterInfoCards.Export
                 return;
 
             curICWidgets.AddWidget(__result, prefab);
+        }
+
+        private static GameObject NormalizeToGameObject(object instance)
+        {
+            switch (instance)
+            {
+                case GameObject gameObject:
+                    return gameObject;
+                case Component component:
+                    return component != null ? component.gameObject : null;
+                default:
+                    return null;
+            }
         }
 
         private static bool ShouldProcessEntry(object entry)


### PR DESCRIPTION
## Summary
- allow ExportWidgets to normalize prefab instances from either GameObject or Component values
- ensure InfoCardWidgets receives the resolved prefab GameObject so shadow bar detection works when the fallback pool is used
- document the outstanding need for a local build and in-game verification of shadow bar capture

## Testing
- not run (environment lacks ONI assemblies and dotnet runtime)


------
https://chatgpt.com/codex/tasks/task_e_68e0f782a3688329a6237353b331df23