### PR TITLE
Improve BetterInfoCards RectTransform metadata handling

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -73,3 +73,8 @@
 ## 2025-10-17 - BetterInfoCards prefab normalization
 - Normalized the widget prefab reference captured by `ExportWidgets` so Harmony fallbacks that expose `Component` instances still map back to the underlying `GameObject`, keeping the `shadowBar` match logic intact.
 - Unable to rebuild `BetterInfoCards` or confirm the fallback captures non-null shadow bar rects in-game because the container lacks the ONI assemblies and runtime; maintainers should run `dotnet build src/oniMods.sln` and validate hover cards wrap across multiple columns locally.
+
+## 2025-10-18 - BetterInfoCards rect metadata fallbacks
+- Expanded the widget export reflection to capture any `RectTransform` field or property regardless of name and cache the `MemberInfo` so fallback pool entries can still be processed.
+- Updated `InfoCardWidgets` to honour the cached metadata, probe `rectTransform`, and fall back to component lookups when necessary so hover cards recover the shadow bar rect even when pools emit raw components.
+- Build and in-game verification remain blocked in this container due to the missing ONI-managed assemblies and `dotnet`; please rebuild via `dotnet build src/oniMods.sln` and validate hover cards wrap across columns after syncing these changes.


### PR DESCRIPTION
## Summary
- capture any RectTransform field or property from hover widget entries and cache the metadata for reuse
- let InfoCardWidgets reuse the cached member info, probe rectTransform fallbacks, and grab RectTransforms from Component entries
- document the missing build/toolchain so maintainers know to rebuild and validate hover card wrapping locally

## Testing
- not run (dotnet runtime and ONI assemblies are unavailable in this container)


------
https://chatgpt.com/codex/tasks/task_e_68e1014d331c8329a5c495d447e69c9c