### PR TITLE
Handle component widget exports without rect metadata

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -78,3 +78,8 @@
 - Expanded the widget export reflection to capture any `RectTransform` field or property regardless of name and cache the `MemberInfo` so fallback pool entries can still be processed.
 - Updated `InfoCardWidgets` to honour the cached metadata, probe `rectTransform`, and fall back to component lookups when necessary so hover cards recover the shadow bar rect even when pools emit raw components.
 - Build and in-game verification remain blocked in this container due to the missing ONI-managed assemblies and `dotnet`; please rebuild via `dotnet build src/oniMods.sln` and validate hover cards wrap across columns after syncing these changes.
+
+## 2025-10-19 - BetterInfoCards component widget handling
+- Adjusted `ExportWidgets.ShouldProcessEntry` to accept component-based entries even when they lack a cached `RectTransform` member and cache the resolved type for subsequent calls so hover widgets exported via component fallbacks remain captured.
+- Hardened `InfoCardWidgets.ExtractRect`'s component accessor to guard against destroyed Unity objects before invoking `GetComponent<RectTransform>()`.
+- Unable to rebuild `BetterInfoCards` or perform the in-game hover wrap validation here because the container still lacks the ONI-managed assemblies and a .NET runtime; maintainers should run `dotnet build src/oniMods.sln` and confirm hover cards wrap into additional columns once the viewport is filled.

--- a/src/BetterInfoCards/Export/ExportWidgets.cs
+++ b/src/BetterInfoCards/Export/ExportWidgets.cs
@@ -294,6 +294,9 @@ namespace BetterInfoCards.Export
 
         private static bool ShouldProcessEntry(object entry)
         {
+            if (entry == null)
+                return false;
+
             var type = entry.GetType();
 
             if (widgetEntryType != null)
@@ -301,16 +304,25 @@ namespace BetterInfoCards.Export
                 if (widgetEntryType.IsInstanceOfType(entry))
                     return true;
 
-                if (widgetEntryType == type)
+                if (type.IsAssignableFrom(widgetEntryType))
                     return true;
             }
 
             var rectMember = GetRectTransformMember(type);
-            if (rectMember == null)
-                return false;
+            if (rectMember != null)
+            {
+                widgetEntryType ??= rectMember.DeclaringType ?? type;
+                return true;
+            }
 
-            widgetEntryType ??= rectMember.DeclaringType ?? type;
-            return true;
+            if (typeof(Component).IsAssignableFrom(type))
+            {
+                if (widgetEntryType == null || typeof(Component).IsAssignableFrom(widgetEntryType))
+                    widgetEntryType = type;
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/src/BetterInfoCards/Info/InfoCardWidgets.cs
+++ b/src/BetterInfoCards/Info/InfoCardWidgets.cs
@@ -206,8 +206,8 @@ namespace BetterInfoCards
             if (typeof(Component).IsAssignableFrom(type))
                 return entry =>
                 {
-                    if (entry is Component component)
-                        return component != null ? component.GetComponent<RectTransform>() : null;
+                    if (entry is Component component && component != null)
+                        return component.GetComponent<RectTransform>();
 
                     return null;
                 };


### PR DESCRIPTION
## Summary
- allow BetterInfoCards widget export to accept component entries that lack cached RectTransform metadata and cache the resolved component type
- guard the component RectTransform accessor against destroyed Unity objects so ExtractRect continues to use Component.GetComponent<RectTransform>()
- document the blocked build and in-game hover wrap validation per the Maintainer Playbook

## Testing
- not run (container lacks the ONI/.NET toolchain required for `dotnet build src/oniMods.sln` and in-game hover validation)

------
https://chatgpt.com/codex/tasks/task_e_68e108e671b48329ad0854f9c88d4ed0