### PR TITLE
Improve rect-based widget matching in BetterInfoCards

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -83,3 +83,8 @@
 - Adjusted `ExportWidgets.ShouldProcessEntry` to accept component-based entries even when they lack a cached `RectTransform` member and cache the resolved type for subsequent calls so hover widgets exported via component fallbacks remain captured.
 - Hardened `InfoCardWidgets.ExtractRect`'s component accessor to guard against destroyed Unity objects before invoking `GetComponent<RectTransform>()`.
 - Unable to rebuild `BetterInfoCards` or perform the in-game hover wrap validation here because the container still lacks the ONI-managed assemblies and a .NET runtime; maintainers should run `dotnet build src/oniMods.sln` and confirm hover cards wrap into additional columns once the viewport is filled.
+
+## 2025-10-20 - BetterInfoCards rect-based widget fallback
+- Added a rect-level comparison in `InfoCardWidgets.AddWidget` so shadow bar and select border assignments succeed even when the prefab clone carries additional components that previously caused the prefab match to fail.
+- The container image still lacks the ONI-managed assemblies and a .NET runtime, so `BetterInfoCards` could not be rebuilt locally. Please run `dotnet build src/oniMods.sln` on a workstation with the full toolchain.
+- In-game validation of multi-column hover wrapping also remains pending for the same reason; once rebuilt, hover a fully populated info card to confirm the second column appears when the viewport fills.

--- a/src/BetterInfoCards/Info/InfoCardWidgets.cs
+++ b/src/BetterInfoCards/Info/InfoCardWidgets.cs
@@ -41,9 +41,11 @@ namespace BetterInfoCards
 
             var skin = HoverTextScreen.Instance.drawer.skin;
 
-            if (MatchesWidgetPrefab(prefab, skin.shadowBarWidget?.gameObject))
+            if (MatchesWidgetPrefab(prefab, skin.shadowBarWidget?.gameObject) ||
+                MatchesWidgetRect(rect, skin.shadowBarWidget))
                 shadowBar = rect;
-            else if (MatchesWidgetPrefab(prefab, skin.selectBorderWidget?.gameObject))
+            else if (MatchesWidgetPrefab(prefab, skin.selectBorderWidget?.gameObject) ||
+                     MatchesWidgetRect(rect, skin.selectBorderWidget))
                 selectBorder = rect;
             else
                 widgets.Add(rect);
@@ -70,6 +72,23 @@ namespace BetterInfoCards
                 return false;
 
             return candidateRect.rect.size == referenceRect.rect.size;
+        }
+
+        private static bool MatchesWidgetRect(RectTransform candidate, RectTransform reference)
+        {
+            if (candidate == null || reference == null)
+                return false;
+
+            if (candidate == reference)
+                return true;
+
+            if (!string.Equals(StripCloneSuffix(candidate.name), StripCloneSuffix(reference.name), StringComparison.Ordinal))
+                return false;
+
+            if (candidate.rect.size != reference.rect.size)
+                return false;
+
+            return HasMatchingComponents(candidate.gameObject, reference.gameObject);
         }
 
         private static string StripCloneSuffix(string name)


### PR DESCRIPTION
## Summary
- add a rect-level fallback in `InfoCardWidgets.AddWidget` so shadow bar and select border detection works even when prefab comparisons fail
- document the outstanding rebuild and in-game hover verification steps in `NOTES.md`

## Testing
- not run (container lacks the ONI/.NET toolchain and game runtime)

------
https://chatgpt.com/codex/tasks/task_e_68e10f6661d48329af93b20a17a5dc4c