### PR TITLE
Fix Better Info Cards widget rect transform comparisons

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -88,3 +88,7 @@
 - Added a rect-level comparison in `InfoCardWidgets.AddWidget` so shadow bar and select border assignments succeed even when the prefab clone carries additional components that previously caused the prefab match to fail.
 - The container image still lacks the ONI-managed assemblies and a .NET runtime, so `BetterInfoCards` could not be rebuilt locally. Please run `dotnet build src/oniMods.sln` on a workstation with the full toolchain.
 - In-game validation of multi-column hover wrapping also remains pending for the same reason; once rebuilt, hover a fully populated info card to confirm the second column appears when the viewport fills.
+
+## 2025-10-21 - BetterInfoCards rect transform comparison fix
+- Updated `InfoCardWidgets.AddWidget` to compare the extracted widget rects against the skin's `RectTransform` instances so component wrappers no longer trigger compile-time mismatches.
+- Attempted to rebuild via `dotnet build src/BetterInfoCards/BetterInfoCards.csproj`, but the container still lacks the `dotnet` host, so maintainers must recompile locally with the ONI-managed assemblies in place.

--- a/src/BetterInfoCards/Info/InfoCardWidgets.cs
+++ b/src/BetterInfoCards/Info/InfoCardWidgets.cs
@@ -42,10 +42,10 @@ namespace BetterInfoCards
             var skin = HoverTextScreen.Instance.drawer.skin;
 
             if (MatchesWidgetPrefab(prefab, skin.shadowBarWidget?.gameObject) ||
-                MatchesWidgetRect(rect, skin.shadowBarWidget))
+                MatchesWidgetRect(rect, skin.shadowBarWidget?.rectTransform))
                 shadowBar = rect;
             else if (MatchesWidgetPrefab(prefab, skin.selectBorderWidget?.gameObject) ||
-                     MatchesWidgetRect(rect, skin.selectBorderWidget))
+                     MatchesWidgetRect(rect, skin.selectBorderWidget?.rectTransform))
                 selectBorder = rect;
             else
                 widgets.Add(rect);


### PR DESCRIPTION
## Summary
- update `InfoCardWidgets.AddWidget` to compare against the skin widgets' `RectTransform` references so rect matching compiles again
- record the rect comparison fix and missing toolchain note in `NOTES.md`

## Testing
- `dotnet build src/BetterInfoCards/BetterInfoCards.csproj` *(fails: `dotnet` host is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e111329954832989813580d4a2f82c