### PR TITLE
Relax shadow bar rect comparison tolerance

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -92,3 +92,7 @@
 ## 2025-10-21 - BetterInfoCards rect transform comparison fix
 - Updated `InfoCardWidgets.AddWidget` to compare the extracted widget rects against the skin's `RectTransform` instances so component wrappers no longer trigger compile-time mismatches.
 - Attempted to rebuild via `dotnet build src/BetterInfoCards/BetterInfoCards.csproj`, but the container still lacks the `dotnet` host, so maintainers must recompile locally with the ONI-managed assemblies in place.
+
+## 2025-10-22 - BetterInfoCards widget rect tolerance
+- Relaxed the `MatchesWidgetRect` comparison to require matching prefab names, component layouts, and rect heights while tolerating minor width differences so fallback-captured shadow bars are recognized.
+- Compilation and in-game verification remain blocked here because the container lacks the ONI-managed assemblies and the `dotnet` runtime; please rebuild via `dotnet build src/oniMods.sln` and confirm multi-column hover wrapping returns with shadow bars detected.

--- a/src/BetterInfoCards/Info/InfoCardWidgets.cs
+++ b/src/BetterInfoCards/Info/InfoCardWidgets.cs
@@ -85,7 +85,16 @@ namespace BetterInfoCards
             if (!string.Equals(StripCloneSuffix(candidate.name), StripCloneSuffix(reference.name), StringComparison.Ordinal))
                 return false;
 
-            if (candidate.rect.size != reference.rect.size)
+            var candidateRect = candidate.rect;
+            var referenceRect = reference.rect;
+
+            const float heightTolerance = 0.01f;
+            const float widthTolerance = 1f;
+
+            if (Mathf.Abs(candidateRect.height - referenceRect.height) > heightTolerance)
+                return false;
+
+            if (Mathf.Abs(candidateRect.width - referenceRect.width) > widthTolerance && referenceRect.width > 0f)
                 return false;
 
             return HasMatchingComponents(candidate.gameObject, reference.gameObject);


### PR DESCRIPTION
## Summary
- relax `InfoCardWidgets.MatchesWidgetRect` to focus on name/component parity and rect height while tolerating minor width differences so fallback shadow bars are captured
- document the new matching tolerance and outstanding build gap in NOTES

## Testing
- not run (missing ONI-managed assemblies and dotnet runtime in container)

------
https://chatgpt.com/codex/tasks/task_e_68e115ac1610832994e3849dbe8aef6c