### PR TITLE
Relax shadow bar width matching for Better Info Cards

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -96,3 +96,7 @@
 ## 2025-10-22 - BetterInfoCards widget rect tolerance
 - Relaxed the `MatchesWidgetRect` comparison to require matching prefab names, component layouts, and rect heights while tolerating minor width differences so fallback-captured shadow bars are recognized.
 - Compilation and in-game verification remain blocked here because the container lacks the ONI-managed assemblies and the `dotnet` runtime; please rebuild via `dotnet build src/oniMods.sln` and confirm multi-column hover wrapping returns with shadow bars detected.
+
+## 2025-10-23 - BetterInfoCards dynamic shadow bar width
+- Removed the strict width comparison inside `InfoCardWidgets.MatchesWidgetRect` so dynamically resized shadow bars still match when names and component layouts align.
+- Unable to rebuild `BetterInfoCards` or perform the in-game hover test here because the container lacks the ONI-managed assemblies and a `dotnet` host; maintainers should run `dotnet build src/oniMods.sln` and validate hover cards wrap into extra columns once wider shadow bars are detected.

--- a/src/BetterInfoCards/Info/InfoCardWidgets.cs
+++ b/src/BetterInfoCards/Info/InfoCardWidgets.cs
@@ -89,12 +89,8 @@ namespace BetterInfoCards
             var referenceRect = reference.rect;
 
             const float heightTolerance = 0.01f;
-            const float widthTolerance = 1f;
 
             if (Mathf.Abs(candidateRect.height - referenceRect.height) > heightTolerance)
-                return false;
-
-            if (Mathf.Abs(candidateRect.width - referenceRect.width) > widthTolerance && referenceRect.width > 0f)
                 return false;
 
             return HasMatchingComponents(candidate.gameObject, reference.gameObject);


### PR DESCRIPTION
## Summary
- remove the strict width comparison in `InfoCardWidgets.MatchesWidgetRect` so dynamically sized shadow bars still match when their names and components align
- document the width-guard relaxation and the blocked rebuild/testing steps in `NOTES.md`

## Testing
- not run (ONI-managed assemblies and dotnet host unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e118ce02748329bca726801dd4528e