### PR TITLE
Ensure Better Info Cards shadow bar accessor prefers matching child rect

### DIFF
--- a/src/BetterInfoCards/Info/InfoCardWidgets.cs
+++ b/src/BetterInfoCards/Info/InfoCardWidgets.cs
@@ -262,14 +262,18 @@ namespace BetterInfoCards
                     if (entry is not Component component || component == null)
                         return null;
 
-                    var rect = component.GetComponent<RectTransform>();
-                    if (rect != null)
-                        return rect;
-
                     var skin = HoverTextScreen.Instance?.drawer?.skin;
                     var referenceRect = skin?.shadowBarWidget?.rectTransform;
-                    if (referenceRect == null)
-                        return null;
+
+                    var rect = component.GetComponent<RectTransform>();
+                    if (rect != null)
+                    {
+                        if (referenceRect == null)
+                            return rect;
+
+                        if (MatchesWidgetRect(rect, referenceRect))
+                            return rect;
+                    }
 
                     var candidates = component.GetComponentsInChildren<RectTransform>(includeInactive: true);
                     foreach (var candidate in candidates)
@@ -281,7 +285,7 @@ namespace BetterInfoCards
                             return candidate;
                     }
 
-                    return null;
+                    return rect;
                 };
 
             return _ => null;


### PR DESCRIPTION
## Summary
- require component rect transforms to match the skin shadow bar before using them
- keep the descendant search as a fallback so the real shadow bar rect is recovered
- return the matching shadow bar rect to AddWidget to restore proper width/height calculations

## Testing
- not run (editor-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e1c0a823788329bf28251537cd63fb