### PR TITLE
Improve Better Info Cards shadow bar pool detection

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -116,3 +116,8 @@
 - Relaxed `InfoCardWidgets.MatchesWidgetRect` so reduced-height shadow bars that still share the prefab name and component layout are treated as matches instead of being rejected by the height check.
 - The container still lacks the ONI-managed assemblies and the `dotnet` runtime, so `BetterInfoCards` could not be rebuilt here; please run `dotnet build src/oniMods.sln` in a full environment.
 - Multi-column hover validation continues to require an in-game hover test after rebuilding to confirm shadow bars with smaller heights restore the secondary column.
+
+## 2025-10-27 - BetterInfoCards shadow bar pool targeting
+- Updated `ExportWidgets.FindWidgetPoolType` to continue scanning HoverTextDrawer members when the nested entry probe fails, prioritizing the shadow bar pool so the postfix captures the correct widgets.
+- Tried to rebuild `BetterInfoCards`, but the container still lacks the ONI-managed assemblies and a `dotnet` host; maintainers should run `dotnet build src/oniMods.sln` in a full environment.
+- In-game confirmation that multi-column hover wrapping now works again remains pending until the mod is rebuilt alongside the game client.


### PR DESCRIPTION
## Summary
- keep scanning HoverTextDrawer pools even when the widget entry lookup fails and prioritize the shadowBars pool so the postfix hooks the shadow bar widgets
- resolve the nested entry type from any located pool before returning to support downstream rect transform checks
- document the blocked local rebuild in NOTES so maintainers can recompile Better Info Cards before verifying multi-column wrapping

## Testing
- not run (dotnet host unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e1d24d96ac8329b518d673f90a935f