### PR TITLE
Relax Better Info Cards collapsed shadow bar rect guard

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -126,3 +126,8 @@
 - Updated `ExportWidgets.FindWidgetEntryTypeRecursive` so nested entry classes that expose a `RectTransform` are preferred over broader value types, ensuring the proper widget entry is discovered for shadow bar pooling.
 - Cached the resolved entry type before verifying the pool and now reconstruct `Pool<T>` with `MakeGenericType` to confirm the patch targets the hover text drawer's widget pool.
 - The container still lacks the ONI-managed assemblies and a `dotnet` runtime, preventing a local rebuild of `BetterInfoCards`; please run `dotnet build src/oniMods.sln` and validate that info card shadow bars regain their dimensions once the mod is rebuilt with the game client.
+
+## 2025-10-29 - BetterInfoCards collapsed shadow bar handling
+- Relaxed `InfoCardWidgets.MatchesWidgetRect` so shadow bars drawn from `Pool<MonoBehaviour>` still match while their runtime height remains collapsed, only rejecting candidates when both the prefab and runtime rects are effectively zero-height.
+- The container still lacks the ONI-managed assemblies and the `dotnet` host, so `BetterInfoCards` could not be rebuilt here; maintainers should run `dotnet build src/oniMods.sln` in a full environment.
+- In-game verification that hover card columns return once the shadow bar sizes update remains pending until the mod is rebuilt alongside the game client.

--- a/src/BetterInfoCards/Info/InfoCardWidgets.cs
+++ b/src/BetterInfoCards/Info/InfoCardWidgets.cs
@@ -90,8 +90,12 @@ namespace BetterInfoCards
 
             const float heightTolerance = 0.01f;
 
-            // Allow shorter runtime instances so long as they are not completely collapsed.
-            if (candidateRect.height <= 0f && referenceRect.height > heightTolerance)
+            // Allow pooled runtime instances that have not yet expanded while still filtering
+            // out placeholder widgets that never acquire a visible height.
+            bool candidateCollapsed = candidateRect.height <= heightTolerance;
+            bool referenceCollapsed = referenceRect.height <= heightTolerance;
+
+            if (candidateCollapsed && referenceCollapsed)
                 return false;
 
             if (HasMatchingComponents(candidate.gameObject, reference.gameObject))


### PR DESCRIPTION
## Summary
- accept shadow bar widgets from the hover drawer pool even when their runtime rect height is still collapsed
- document the change and the outstanding rebuild and in-game validation in `NOTES.md`

## Testing
- not run `dotnet build src/oniMods.sln` (missing ONI assemblies and dotnet host in container)
- not run in-game Better Info Cards validation (ONI client unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e1dd267b5c8329b31682fd4002a366