### PR TITLE
Allow collapsed shadow bars to pass rect matching

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -131,3 +131,8 @@
 - Relaxed `InfoCardWidgets.MatchesWidgetRect` so shadow bars drawn from `Pool<MonoBehaviour>` still match while their runtime height remains collapsed, only rejecting candidates when both the prefab and runtime rects are effectively zero-height.
 - The container still lacks the ONI-managed assemblies and the `dotnet` host, so `BetterInfoCards` could not be rebuilt here; maintainers should run `dotnet build src/oniMods.sln` in a full environment.
 - In-game verification that hover card columns return once the shadow bar sizes update remains pending until the mod is rebuilt alongside the game client.
+
+## 2025-10-30 - BetterInfoCards collapsed rect matching
+- Removed the zero-height short-circuit inside `InfoCardWidgets.MatchesWidgetRect` so shadow bars that remain collapsed while pooled still run through the component matching heuristics.
+- The container continues to lack the ONI-managed assemblies and a `dotnet` host, preventing a local rebuild of `BetterInfoCards`; please execute `dotnet build src/oniMods.sln` in a full environment.
+- In-game confirmation that `shadowBar` now reports a non-null rect (restoring multi-column wrapping) remains pending until the mod is rebuilt and loaded with the game client.

--- a/src/BetterInfoCards/Info/InfoCardWidgets.cs
+++ b/src/BetterInfoCards/Info/InfoCardWidgets.cs
@@ -95,9 +95,6 @@ namespace BetterInfoCards
             bool candidateCollapsed = candidateRect.height <= heightTolerance;
             bool referenceCollapsed = referenceRect.height <= heightTolerance;
 
-            if (candidateCollapsed && referenceCollapsed)
-                return false;
-
             if (HasMatchingComponents(candidate.gameObject, reference.gameObject))
                 return true;
 


### PR DESCRIPTION
## Summary
- remove the collapsed-rect early return in MatchesWidgetRect so shadow bars that still share the prefab metadata flow through the component heuristics
- document the change and the pending rebuild/in-game validation requirements in NOTES.md

## Testing
- not run (dotnet runtime and ONI-managed assemblies unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e1dffdcc3c8329a1116f42398d8074