### PR TITLE
Guard info card replay when drawer unavailable

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -136,3 +136,8 @@
 - Removed the zero-height short-circuit inside `InfoCardWidgets.MatchesWidgetRect` so shadow bars that remain collapsed while pooled still run through the component matching heuristics.
 - The container continues to lack the ONI-managed assemblies and a `dotnet` host, preventing a local rebuild of `BetterInfoCards`; please execute `dotnet build src/oniMods.sln` in a full environment.
 - In-game confirmation that `shadowBar` now reports a non-null rect (restoring multi-column wrapping) remains pending until the mod is rebuilt and loaded with the game client.
+
+## 2025-10-31 - BetterInfoCards drawer null safety
+- Updated the hover info replay to cache the `HoverTextDrawer` instance and short-circuit when it is unavailable so captured actions are never re-run without a live drawer.
+- Routed `InfoCard` and `DrawActions` rendering through the cached drawer reference, emitting a warning when the drawer is missing to avoid Unity exceptions.
+- Unable to recompile or verify hover card recovery in-game inside this container because the ONI-managed assemblies and runtime remain unavailable; maintainers should rebuild via `dotnet build src/oniMods.sln` and confirm that layout is skipped (without crashing) when the drawer hook fails.

--- a/src/BetterInfoCards/Info/DisplayCard.cs
+++ b/src/BetterInfoCards/Info/DisplayCard.cs
@@ -18,11 +18,11 @@ namespace BetterInfoCards
                 visCardIndex = 0;
         }
 
-        public void Draw()
+        public void Draw(HoverTextDrawer drawer)
         {
             // Explicitly drawing the VisCard is not necessary for 99% of cases.
             // However, custom converters could be created to group different values together.
-            VisCard.Draw(infoCards, visCardIndex);
+            VisCard.Draw(infoCards, visCardIndex, drawer);
         }
 
         public List<KSelectable> GetAllSelectables()

--- a/src/BetterInfoCards/Info/DrawActions.cs
+++ b/src/BetterInfoCards/Info/DrawActions.cs
@@ -7,7 +7,7 @@ namespace BetterInfoCards
     // The interface would cause boxing, making performance even worse.
     public abstract class DrawActions
     {
-        public abstract void Draw(List<InfoCard> cards);
+        public abstract void Draw(List<InfoCard> cards, HoverTextDrawer drawer);
 
         public class Text : DrawActions
         {
@@ -27,9 +27,9 @@ namespace BetterInfoCards
                 return this;
             }
 
-            public override void Draw(List<InfoCard> cards)
+            public override void Draw(List<InfoCard> cards, HoverTextDrawer drawer)
             {
-                InterceptHoverDrawer.drawerInstance.DrawText(ti.GetTextOverride(cards), style, color, overrideColor);
+                drawer.DrawText(ti.GetTextOverride(cards), style, color, overrideColor);
             }
         }
 
@@ -49,9 +49,9 @@ namespace BetterInfoCards
                 return this;
             }
 
-            public override void Draw(List<InfoCard> _)
+            public override void Draw(List<InfoCard> _, HoverTextDrawer drawer)
             {
-                InterceptHoverDrawer.drawerInstance.DrawIcon(icon, color, imageSize, horizontalSpacing);
+                drawer.DrawIcon(icon, color, imageSize, horizontalSpacing);
             }
         }
 
@@ -65,9 +65,9 @@ namespace BetterInfoCards
                 return this;
             }
 
-            public override void Draw(List<InfoCard> _)
+            public override void Draw(List<InfoCard> _, HoverTextDrawer drawer)
             {
-                InterceptHoverDrawer.drawerInstance.AddIndent(width);
+                drawer.AddIndent(width);
             }
         }
 
@@ -81,9 +81,9 @@ namespace BetterInfoCards
                 return this;
             }
 
-            public override void Draw(List<InfoCard> _)
+            public override void Draw(List<InfoCard> _, HoverTextDrawer drawer)
             {
-                InterceptHoverDrawer.drawerInstance.NewLine(minHeight);
+                drawer.NewLine(minHeight);
             }
         }
     }

--- a/src/BetterInfoCards/Info/InfoCard.cs
+++ b/src/BetterInfoCards/Info/InfoCard.cs
@@ -31,8 +31,14 @@ namespace BetterInfoCards
 
         public string GetTitleKey() => titleDrawer.ti?.Text.RemoveCountSuffix() ?? string.Empty;
 
-        public void Draw(List<InfoCard> cards, int visCardIndex)
+        public void Draw(List<InfoCard> cards, int visCardIndex, HoverTextDrawer drawer)
         {
+            if (drawer == null)
+            {
+                Debug.LogWarning("[BetterInfoCards] Skipping info card draw because HoverTextDrawer instance is unavailable.");
+                return;
+            }
+
             if (visCardIndex > 0 && titleDrawer.style != null)
             {
                 var ti = TextInfo.Create(string.Empty, " #" + (++visCardIndex), null);
@@ -40,12 +46,12 @@ namespace BetterInfoCards
                 drawActions.Insert(++titleDrawer.drawIndex, drawCount);
             }
 
-            InterceptHoverDrawer.drawerInstance.BeginShadowBar(isSelected);
+            drawer.BeginShadowBar(isSelected);
 
             foreach (var info in drawActions)
-                info.Draw(cards);
+                info.Draw(cards, drawer);
 
-            InterceptHoverDrawer.drawerInstance.EndShadowBar();
+            drawer.EndShadowBar();
         }
 
         public void AddDraw(DrawActions drawAction) => drawActions.Add(drawAction);

--- a/src/BetterInfoCards/Process/ProcessHoverInfo.cs
+++ b/src/BetterInfoCards/Process/ProcessHoverInfo.cs
@@ -1,6 +1,7 @@
 using BetterInfoCards.Export;
 using BetterInfoCards.Process;
 using HarmonyLib;
+using UnityEngine;
 
 namespace BetterInfoCards
 {
@@ -9,6 +10,15 @@ namespace BetterInfoCards
     {
         static void Prefix()
         {
+            var drawer = InterceptHoverDrawer.drawerInstance;
+            if (drawer == null)
+            {
+                if (InterceptHoverDrawer.IsInterceptMode)
+                    InterceptHoverDrawer.IsInterceptMode = false;
+                Debug.LogWarning("[BetterInfoCards] HoverTextDrawer instance is missing; skipping info card replay.");
+                return;
+            }
+
             var infoCards = InterceptHoverDrawer.ConsumeInfoCards();
             var displayCards = new DisplayCards().UpdateData(infoCards);
 
@@ -16,7 +26,7 @@ namespace BetterInfoCards
 
             InterceptHoverDrawer.IsInterceptMode = false;
             foreach (var card in displayCards)
-                card.Draw();
+                card.Draw(drawer);
             InterceptHoverDrawer.IsInterceptMode = true;
 
             var widgets = ExportWidgets.ConsumeWidgets();


### PR DESCRIPTION
## Summary
- cache the active HoverTextDrawer before replaying captured hover info and abort safely when it is missing
- route InfoCard and DrawActions rendering through the cached drawer and emit warnings instead of crashing when unavailable
- document the outstanding in-game validation required for the new null-guarded flow

## Testing
- not run (container lacks the ONI runtime and managed assemblies needed for in-game validation)


------
https://chatgpt.com/codex/tasks/task_e_68e1e7c7e160832982ecda2257be68cc