### PR TITLE
Guard hover drawer actions when the active card is missing

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -146,3 +146,8 @@
 - Switched the shadow bar capture to allocate its widget container during the `BeginShadowBar` prefix so the subsequent `Draw()` call receives a ready list and no longer skips the first widget entry.
 - Added a replay-phase fallback in the widget postfix to lazily create the container when the prefix is bypassed, keeping the `IsInterceptMode` guard so live draws remain untouched.
 - The ONI-managed assemblies and runtime are still unavailable here, so `dotnet build src/oniMods.sln` and in-game hover validation of multi-column wrapping must be performed in a full environment.
+
+## 2025-11-02 - BetterInfoCards hover drawer null guards
+- Hardened the hover drawer patches so every `DrawIcon`, `DrawText`, `AddIndent`, `NewLine`, and `EndShadowBar` prefix verifies `curInfoCard` before replaying captured actions, logging and deferring to vanilla rendering when the card context is missing.
+- Reset `curInfoCard` whenever `BeginShadowBar` skips allocation to avoid replaying into a stale card when the intercept path is bypassed.
+- Compilation and in-game hover validation remain blocked in this container due to missing ONI-managed assemblies and the `dotnet` host; maintainers should rebuild via `dotnet build src/oniMods.sln` and confirm hover cards render safely when the drawer skips `BeginShadowBar`.

--- a/src/BetterInfoCards/Export/InterceptHoverDrawer.cs
+++ b/src/BetterInfoCards/Export/InterceptHoverDrawer.cs
@@ -42,6 +42,8 @@ namespace BetterInfoCards
             {
                 if (IsInterceptMode)
                     infoCards.Add(curInfoCard = pool.Get().Set(selected));
+                else
+                    curInfoCard = null;
                 return !IsInterceptMode;
             }
         }
@@ -54,9 +56,17 @@ namespace BetterInfoCards
             [HarmonyPriority(Priority.First)]
             static bool Prefix(Sprite icon, Color color, int image_size, int horizontal_spacing)
             {
-                if (IsInterceptMode)
-                    curInfoCard.AddDraw(pool.Get().Set(icon, color, image_size, horizontal_spacing));
-                return !IsInterceptMode;
+                if (!IsInterceptMode)
+                    return true;
+
+                if (curInfoCard == null)
+                {
+                    Debug.LogWarning("[BetterInfoCards] DrawIcon received without an active info card; falling back to HoverTextDrawer.");
+                    return true;
+                }
+
+                curInfoCard.AddDraw(pool.Get().Set(icon, color, image_size, horizontal_spacing));
+                return false;
             }
         }
 
@@ -70,13 +80,22 @@ namespace BetterInfoCards
             {
                 // Null check avoids crashes from drawing multiple empty strings.
                 // This appears to now occur when hovering neutromium tiles.
-                if (IsInterceptMode && !text.IsNullOrWhiteSpace())
+                if (!IsInterceptMode)
+                    return true;
+
+                if (curInfoCard == null)
+                {
+                    Debug.LogWarning("[BetterInfoCards] DrawText received without an active info card; falling back to HoverTextDrawer.");
+                    return true;
+                }
+
+                if (!text.IsNullOrWhiteSpace())
                 {
                     var (id, data) = ExportSelectToolData.ConsumeTextInfo();
                     var ti = TextInfo.Create(id, text, data);
                     curInfoCard.AddDraw(pool.Get().Set(ti, style, color, override_color), ti);
                 }
-                return !IsInterceptMode;
+                return false;
             }
         }
 
@@ -88,9 +107,17 @@ namespace BetterInfoCards
             [HarmonyPriority(Priority.First)]
             static bool Prefix(int width)
             {
-                if (IsInterceptMode)
-                    curInfoCard.AddDraw(pool.Get().Set(width));
-                return !IsInterceptMode;
+                if (!IsInterceptMode)
+                    return true;
+
+                if (curInfoCard == null)
+                {
+                    Debug.LogWarning("[BetterInfoCards] AddIndent received without an active info card; falling back to HoverTextDrawer.");
+                    return true;
+                }
+
+                curInfoCard.AddDraw(pool.Get().Set(width));
+                return false;
             }
         }
 
@@ -102,9 +129,17 @@ namespace BetterInfoCards
             [HarmonyPriority(Priority.First)]
             static bool Prefix(int min_height)
             {
-                if (IsInterceptMode)
-                    curInfoCard.AddDraw(pool.Get().Set(min_height));
-                return !IsInterceptMode;
+                if (!IsInterceptMode)
+                    return true;
+
+                if (curInfoCard == null)
+                {
+                    Debug.LogWarning("[BetterInfoCards] NewLine received without an active info card; falling back to HoverTextDrawer.");
+                    return true;
+                }
+
+                curInfoCard.AddDraw(pool.Get().Set(min_height));
+                return false;
             }
         }
 
@@ -114,9 +149,17 @@ namespace BetterInfoCards
             [HarmonyPriority(Priority.First)]
             static bool Prefix()
             {
-                if (IsInterceptMode)
-                    curInfoCard.selectable = ExportSelectToolData.ConsumeSelectable();
-                return !IsInterceptMode;
+                if (!IsInterceptMode)
+                    return true;
+
+                if (curInfoCard == null)
+                {
+                    Debug.LogWarning("[BetterInfoCards] EndShadowBar received without an active info card; falling back to HoverTextDrawer.");
+                    return true;
+                }
+
+                curInfoCard.selectable = ExportSelectToolData.ConsumeSelectable();
+                return false;
             }
         }
     }


### PR DESCRIPTION
## Summary
- guard each hover drawer prefix so the vanilla drawer handles calls when the intercepted card context is missing
- reset the active info card whenever the BeginShadowBar prefix skips allocation to avoid reusing stale cards
- document the null-guard hardening and outstanding rebuild/test needs in NOTES.md

## Testing
- not run (missing ONI-managed assemblies and dotnet host in container)


------
https://chatgpt.com/codex/tasks/task_e_68e1eee37a748329921de39ebeb2012a