### PR TITLE
Guard hover shadow bar rects until layout resolves

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -151,3 +151,8 @@
 - Hardened the hover drawer patches so every `DrawIcon`, `DrawText`, `AddIndent`, `NewLine`, and `EndShadowBar` prefix verifies `curInfoCard` before replaying captured actions, logging and deferring to vanilla rendering when the card context is missing.
 - Reset `curInfoCard` whenever `BeginShadowBar` skips allocation to avoid replaying into a stale card when the intercept path is bypassed.
 - Compilation and in-game hover validation remain blocked in this container due to missing ONI-managed assemblies and the `dotnet` host; maintainers should rebuild via `dotnet build src/oniMods.sln` and confirm hover cards render safely when the drawer skips `BeginShadowBar`.
+
+## 2025-11-03 - BetterInfoCards shadow bar sizing guard
+- Added a collapse tolerance guard to `InfoCardWidgets.MatchesWidgetRect` so zero-height shadow bars stay pending until either the prefab or runtime rect expands past the threshold, preventing collapsed rects from short-circuiting the match.
+- Cached collapsed shadow bar candidates and re-checked them before grid layout, ensuring the grid only measures non-zero width/height rects and column wrapping resumes once Unity finishes sizing the widget.
+- The ONI-managed assemblies and `dotnet` host are still unavailable here, so rebuild `BetterInfoCards` via `dotnet build src/oniMods.sln` on a full workstation and validate in-game that the grid now captures positive shadow bar dimensions.

--- a/src/BetterInfoCards/Info/Grid.cs
+++ b/src/BetterInfoCards/Info/Grid.cs
@@ -30,6 +30,9 @@ namespace BetterInfoCards
             if (cards.Count == 0)
                 return;
 
+            foreach (var card in cards)
+                card?.ResolvePendingWidgets();
+
             var offset = new Vector2(0f, topY);
 
             columns.Clear();


### PR DESCRIPTION
## Summary
- gate shadow bar matching on a collapse tolerance and queue unsized rects for a later retry
- retry pending shadow bar assignments before building the grid so width/height values stay positive for wrapping
- log the guard and follow-up requirements in NOTES.md per the Maintainer Playbook

## Testing
- Not run (container lacks the ONI-managed assemblies and dotnet per the Maintainer Playbook)

------
https://chatgpt.com/codex/tasks/task_e_68e1f0721318832982e8e89c8f9dff7c