### PR TITLE
Align ResetPool constructors with shared reset handler

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -166,3 +166,8 @@
 - Short-circuited the Harmony prefixes in `InterceptHoverDrawer` so they immediately defer to the vanilla drawer when `curInfoCard` is unavailable, preventing null dereferences when the widget pool hook is missing.
 - Added a one-shot warning and reset `IsInterceptMode` after the fallback triggers to avoid repeatedly re-entering the prefixes without a valid card in the same frame.
 - Could not rebuild `BetterInfoCards` inside this container because the ONI-managed assemblies and `dotnet` runtime are still absent; maintainers should run `dotnet build src/oniMods.sln` locally and replay a hover sequence to confirm the fallback no longer throws.
+
+## 2025-11-05 - BetterInfoCards reset pool constructor parity
+- Updated `ResetPool` so the single-parameter constructor now combines `HoverTextDrawer.BeginDrawing` with the `Reset` handler, matching the multiparameter overload.
+- Centralized the delegate hookup through `AttachResetHandler` to keep both constructors in sync and expose the combined delegate via `OnBeginDrawing` for telemetry consumers.
+- Rebuild and hover replay verification remain blocked here because the ONI-managed assemblies and `dotnet` runtime are unavailable; please run `dotnet build src/oniMods.sln` and confirm pooled draw actions reset on each `HoverTextDrawer.BeginDrawing` in a full environment.

--- a/src/BetterInfoCards/Util/ResetPool.cs
+++ b/src/BetterInfoCards/Util/ResetPool.cs
@@ -42,13 +42,12 @@ namespace BetterInfoCards
             this.trimSlack = trimSlack;
             idleTrimThreshold = ToStopwatchTicks(idleTrimAge ?? TimeSpan.FromSeconds(30));
 
-            System.Action resetHandler = Reset;
-            resetOn = (System.Action)Delegate.Combine(resetOn, resetHandler);
+            AttachResetHandler(ref resetOn);
         }
 
         public ResetPool(ref System.Action onBeginDrawing)
         {
-            OnBeginDrawing = onBeginDrawing;
+            AttachResetHandler(ref onBeginDrawing);
         }
 
         public int Count
@@ -68,7 +67,7 @@ namespace BetterInfoCards
 
         public int LastCycleUsage => Volatile.Read(ref lastCycleUsage);
 
-        public System.Action OnBeginDrawing { get; }
+        public System.Action OnBeginDrawing { get; private set; }
 
         public TimeSpan GetIdleTimeFor(int index)
         {
@@ -147,6 +146,13 @@ namespace BetterInfoCards
                     consecutiveLowUsageCycles = 0;
                 }
             }
+        }
+
+        private void AttachResetHandler(ref System.Action onBeginDrawing)
+        {
+            System.Action resetHandler = Reset;
+            onBeginDrawing = (System.Action)Delegate.Combine(onBeginDrawing, resetHandler);
+            OnBeginDrawing = onBeginDrawing;
         }
 
         private void TrimPool(long now, int requiredCount)


### PR DESCRIPTION
## Summary
- update ResetPool so both constructors attach Reset to the provided HoverTextDrawer.BeginDrawing delegate
- centralize the delegate wiring in AttachResetHandler and expose the combined action through OnBeginDrawing
- document the reset handler parity follow-up in NOTES.md for maintainers

## Testing
- not run (container lacks the ONI-managed assemblies and dotnet runtime required to build BetterInfoCards)


------
https://chatgpt.com/codex/tasks/task_e_68e20228d7b48329808898376dc94d5d