### PR TITLE
Guard BetterInfoCards hover text replay against null converters

### DIFF
--- a/ERRORS.md
+++ b/ERRORS.md
@@ -1,0 +1,7 @@
+# Error Log
+
+## 2025-11-07 - BetterInfoCards converter null guard
+- **Module:** BetterInfoCards hover info replay
+- **Issue:** Converters that returned `null` produced draw actions without a valid `TextInfo`, causing crashes when the hover drawer replay attempted to dereference the missing converter output.
+- **Resolution:** Guarded `TextInfo.Create` and the replay draw call so null converters log a warning and skip rendering instead of invoking `HoverTextDrawer.DrawText` with invalid data.
+- **Status:** Fixed

--- a/NOTES.md
+++ b/NOTES.md
@@ -176,3 +176,8 @@
 - Tightened the component fallback in `InfoCardWidgets.CreateAccessor` so only the component's own `RectTransform` that matches the skin's shadow bar is returned, otherwise descendants are scanned and unmatched entries report `null`.
 - Updated `InfoCardWidgets.AddWidget` and `TryAssignShadowBar` to tolerate null rect accessors, keep probing for later matches, and cache the resolved rect (even while collapsed) as `shadowBar`.
 - Could not rebuild `BetterInfoCards` inside this container because the ONI-managed assemblies and `dotnet` runtime are still missing; maintainers should run `dotnet build src/oniMods.sln` locally and confirm hover cards regain positive widths and wrap into additional columns in-game once rebuilt.
+
+## 2025-11-07 - BetterInfoCards converter null guard
+- Added a null check around `TextInfo.Create` in the hover drawer intercept so converter failures log a warning and skip the draw instead of queuing a crashing replay action.
+- Ensured replayed text actions bail out when either the captured `TextInfo` or `TextStyleSetting` is unavailable so the hover text drawer is never invoked with missing data.
+- Compilation and in-game verification remain blocked in this container because the ONI-managed assemblies and `dotnet` runtime are unavailable; maintainers should rebuild via `dotnet build src/oniMods.sln` and hover a converted info card to confirm the warning path prevents crashes.

--- a/src/BetterInfoCards/Export/InterceptHoverDrawer.cs
+++ b/src/BetterInfoCards/Export/InterceptHoverDrawer.cs
@@ -89,6 +89,12 @@ namespace BetterInfoCards
                 {
                     var (id, data) = ExportSelectToolData.ConsumeTextInfo();
                     var ti = TextInfo.Create(id, text, data);
+                    if (ti == null)
+                    {
+                        Debug.LogWarning($"[BetterInfoCards] Text converter '{id ?? "<default>"}' returned null; skipping DrawText replay.");
+                        return false;
+                    }
+
                     curInfoCard.AddDraw(pool.Get().Set(ti, style, color, override_color), ti);
                 }
                 return false;

--- a/src/BetterInfoCards/Info/DrawActions.cs
+++ b/src/BetterInfoCards/Info/DrawActions.cs
@@ -29,6 +29,18 @@ namespace BetterInfoCards
 
             public override void Draw(List<InfoCard> cards, HoverTextDrawer drawer)
             {
+                if (ti == null)
+                {
+                    Debug.LogWarning("[BetterInfoCards] Skipping DrawText replay because the captured TextInfo is missing.");
+                    return;
+                }
+
+                if (style == null)
+                {
+                    Debug.LogWarning("[BetterInfoCards] Skipping DrawText replay because the captured TextStyleSetting is missing.");
+                    return;
+                }
+
                 drawer.DrawText(ti.GetTextOverride(cards), style, color, overrideColor);
             }
         }


### PR DESCRIPTION
## Summary
- skip pooled DrawText actions when `TextInfo.Create` returns null so hover replays no longer enqueue invalid work
- short-circuit replayed text actions if their captured `TextInfo` or `TextStyleSetting` is missing to prevent null dereferences
- document the crash fix in the project notes and error log for maintainers

## Testing
- not run (dotnet/ONI assemblies unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e23a0a719c83298f93b50ee180ff89