### PR TITLE
Guard BetterInfoCards title converter against missing PrimaryElement

### DIFF
--- a/ERRORS.md
+++ b/ERRORS.md
@@ -5,3 +5,9 @@
 - **Issue:** Converters that returned `null` produced draw actions without a valid `TextInfo`, causing crashes when the hover drawer replay attempted to dereference the missing converter output.
 - **Resolution:** Guarded `TextInfo.Create` and the replay draw call so null converters log a warning and skip rendering instead of invoking `HoverTextDrawer.DrawText` with invalid data.
 - **Status:** Fixed
+
+## 2025-11-09 - BetterInfoCards title converter null guard
+- **Module:** BetterInfoCards hover title aggregation
+- **Issue:** Countable prefabs missing a `PrimaryElement` caused the title converter to dereference a null component while computing `Units`, crashing the hover drawer replay.
+- **Resolution:** Cached the `PrimaryElement`, logged a one-shot warning when absent, and returned a safe default so the aggregation can continue without throwing.
+- **Status:** Fixed

--- a/NOTES.md
+++ b/NOTES.md
@@ -186,3 +186,8 @@
 - Added a deferred resolver that schedules collapsed shadow bar candidates for a `LateUpdate` retry so the grid promotes them once Unity expands their rects, ensuring width/height reflect the final layout before wrapping columns.
 - The new scheduler only reuses `ResolvePendingWidgets` and leaves the prefab/rect matching heuristics untouched, so existing comparisons against the hover drawer skin continue to behave as before.
 - Could not rebuild or run in-game validation here because the ONI-managed assemblies and `dotnet` runtime remain unavailable; please execute `dotnet build src/oniMods.sln` in a full environment and verify hover cards populate multi-column layouts after the deferred sizing pass.
+
+## 2025-11-09 - BetterInfoCards title converter null guard
+- Hardened the title converter so countable prefabs without a `PrimaryElement` return a safe default and emit a one-shot warning instead of crashing when `.Units` is missing.
+- Mirrored the ore status converter pattern by caching the component lookup before accessing aggregation data.
+- Unable to rebuild `BetterInfoCards` in this container because the ONI assemblies and `dotnet` host are absent; maintainers should run `dotnet build src/oniMods.sln` locally and confirm the hover title aggregation no longer throws when encountering prefabs without `PrimaryElement`.


### PR DESCRIPTION
## Summary
- add a cached PrimaryElement lookup to the BetterInfoCards title converter and log once when the component is missing
- return a safe default for non-countable titles so the aggregation path no longer crashes on null Units
- document the null-guard fix in ERRORS.md and NOTES.md for maintainers

## Testing
- not run (container lacks the ONI-managed assemblies and dotnet host)

------
https://chatgpt.com/codex/tasks/task_e_68e23fc4d81883299a2be24be1215238