### PR TITLE
Allow vanilla fallback when DrawText conversion fails

### DIFF
--- a/src/BetterInfoCards/Export/InterceptHoverDrawer.cs
+++ b/src/BetterInfoCards/Export/InterceptHoverDrawer.cs
@@ -91,8 +91,9 @@ namespace BetterInfoCards
                     var ti = TextInfo.Create(id, text, data);
                     if (ti == null)
                     {
-                        Debug.LogWarning($"[BetterInfoCards] Text converter '{id ?? "<default>"}' returned null; skipping DrawText replay.");
-                        return false;
+                        Debug.LogWarning($"[BetterInfoCards] Text converter '{id ?? "<default>"}' returned null; falling back to vanilla DrawText.");
+                        // Returning true allows the vanilla drawer to render the text when our converter fails.
+                        return true;
                     }
 
                     curInfoCard.AddDraw(pool.Get().Set(ti, style, color, override_color), ti);


### PR DESCRIPTION
## Summary
- let DrawText revert to the vanilla renderer when a text converter returns null
- update the log message and inline comment to document the fallback behavior

## Testing
- not run (environment lacks ONI/.NET runtime)

------
https://chatgpt.com/codex/tasks/task_e_68e242515c908329845d0ce2890df572