### PR TITLE
Defer grid layout until shadow bars resolve

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -196,3 +196,8 @@
 - Added a prefab-based fallback in `InfoCardWidgets.AddWidget` so the shadow bar rect is recovered directly from the instantiated prefab when the pool entry lacks an accessor.
 - Queued unresolved prefabs for deferred processing alongside collapsed rects, allowing `ResolvePendingWidgets` to revisit them once Unity finishes the layout pass and the rect reports a usable size.
 - Compilation and in-game verification remain blocked here because the container lacks the ONI-managed assemblies and `dotnet`; maintainers should rebuild via `dotnet build src/oniMods.sln` and confirm captured cards regain non-zero dimensions and column wrapping in-game.
+
+## 2025-11-11 - BetterInfoCards deferred grid relayout
+- Updated `InfoCardWidgets.ResolvePendingWidgets` to expose the pending/resolved state so grid layout can detect when shadow bars are still sizing.
+- Reworked `Grid` to defer column measurement for pending cards, schedule a late-update relayout once the deferred resolver promotes them, and apply the final layout only after the shadow bar reports usable dimensions.
+- Unable to rebuild or run in-game validation because the container still lacks the ONI-managed assemblies and a `dotnet` runtime; maintainers should run `dotnet build src/oniMods.sln` locally and verify multi-column wrapping after the deferred pass completes.

--- a/src/BetterInfoCards/Info/Grid.cs
+++ b/src/BetterInfoCards/Info/Grid.cs
@@ -7,7 +7,12 @@ namespace BetterInfoCards
     {
         private const float shadowBarSpacing = 4f;
 
-        List<Column> columns = new();
+        private readonly List<InfoCardWidgets> cards;
+        private readonly List<Column> columns = new();
+        private readonly float topY;
+        private bool hasPendingCards;
+        private bool layoutApplied;
+        private bool columnsDirty = true;
 
         // The HoverTextScreen is initialized before CameraController
         private float _minY = float.MaxValue;
@@ -27,44 +32,49 @@ namespace BetterInfoCards
 
         public Grid(List<InfoCardWidgets> cards, float topY)
         {
-            if (cards.Count == 0)
+            this.cards = cards ?? new List<InfoCardWidgets>();
+            this.topY = topY;
+
+            if (this.cards.Count == 0)
                 return;
 
-            foreach (var card in cards)
-                card?.ResolvePendingWidgets();
+            var pendingCards = new List<InfoCardWidgets>();
 
-            var offset = new Vector2(0f, topY);
-
-            columns.Clear();
-            var col = new Column();
-
-            for (int i = 0; i < cards.Count; i++)
+            foreach (var card in this.cards)
             {
-                var card = cards[i];
+                if (card == null)
+                    continue;
 
-                // If the first one can't fit, put it down anyways otherwise they all get shifted over by the shadow bar spacing.
-                if (offset.y - card.Height < MinY + shadowBarSpacing && i > 0)
-                {
-                    offset.x += col.maxXInCol + shadowBarSpacing;
-                    columns.Add(col);
-                    col = new() { offsetX = offset.x };
-                    offset.y = topY;
-                }
-
-                card.offset.y = offset.y - card.YMax;
-                offset.y -= card.Height + shadowBarSpacing;
-
-                if (card.Width > col.maxXInCol)
-                    col.maxXInCol = card.Width;
-
-                col.cards.Add(card);
+                var state = card.ResolvePendingWidgets();
+                if (state == InfoCardWidgets.PendingShadowBarState.Pending)
+                    pendingCards.Add(card);
             }
 
-            columns.Add(col);
+            hasPendingCards = pendingCards.Count > 0;
+
+            if (hasPendingCards)
+                DeferredLayoutScheduler.Register(this, pendingCards);
         }
 
         public void MoveAndResizeInfoCards()
         {
+            ApplyLayoutIfReady();
+        }
+
+        private void ApplyLayoutIfReady()
+        {
+            if (layoutApplied)
+                return;
+
+            if (hasPendingCards)
+                return;
+
+            if (columnsDirty)
+            {
+                BuildColumns();
+                columnsDirty = false;
+            }
+
             for (int i = columns.Count - 1; i >= 0; i--)
             {
                 float colToRightYMin = float.MaxValue;
@@ -73,6 +83,206 @@ namespace BetterInfoCards
                     colToRightYMin = columns[i + 1].YMin;
 
                 columns[i].MoveAndResize(colToRightYMin);
+            }
+
+            layoutApplied = true;
+        }
+
+        private void BuildColumns()
+        {
+            columns.Clear();
+
+            if (cards.Count == 0)
+                return;
+
+            var offset = new Vector2(0f, topY);
+            var column = new Column();
+            int placedCount = 0;
+
+            for (int i = 0; i < cards.Count; i++)
+            {
+                var card = cards[i];
+
+                if (card == null)
+                    continue;
+
+                card.ResolvePendingWidgets();
+
+                // If the first one can't fit, put it down anyways otherwise they all get shifted over by the shadow bar spacing.
+                if (offset.y - card.Height < MinY + shadowBarSpacing && placedCount > 0)
+                {
+                    offset.x += column.maxXInCol + shadowBarSpacing;
+                    columns.Add(column);
+                    column = new Column { offsetX = offset.x };
+                    offset.y = topY;
+                }
+
+                card.offset.y = offset.y - card.YMax;
+                offset.y -= card.Height + shadowBarSpacing;
+
+                if (card.Width > column.maxXInCol)
+                    column.maxXInCol = card.Width;
+
+                column.cards.Add(card);
+                placedCount++;
+            }
+
+            if (column.cards.Count > 0)
+                columns.Add(column);
+        }
+
+        private void OnPendingCardsResolved()
+        {
+            hasPendingCards = false;
+            columnsDirty = true;
+            layoutApplied = false;
+            ApplyLayoutIfReady();
+        }
+
+        private static class DeferredLayoutScheduler
+        {
+            private static readonly List<PendingLayout> pendingLayouts = new();
+            private static LateUpdateDriver driver;
+
+            public static void Register(Grid grid, List<InfoCardWidgets> pendingCards)
+            {
+                if (grid == null || pendingCards == null || pendingCards.Count == 0)
+                    return;
+
+                var layout = GetOrCreateLayout(grid);
+                layout.ReplacePendingCards(pendingCards);
+
+                EnsureDriver()?.Activate();
+            }
+
+            private static PendingLayout GetOrCreateLayout(Grid grid)
+            {
+                for (int i = 0; i < pendingLayouts.Count; i++)
+                {
+                    var existing = pendingLayouts[i];
+                    if (existing.IsFor(grid))
+                        return existing;
+                }
+
+                var layout = new PendingLayout(grid);
+                pendingLayouts.Add(layout);
+                return layout;
+            }
+
+            private static void Process()
+            {
+                for (int i = pendingLayouts.Count - 1; i >= 0; i--)
+                {
+                    var layout = pendingLayouts[i];
+
+                    if (!layout.TryComplete())
+                        continue;
+
+                    pendingLayouts.RemoveAt(i);
+                }
+
+                if (pendingLayouts.Count == 0 && driver != null)
+                    driver.enabled = false;
+            }
+
+            private static LateUpdateDriver EnsureDriver()
+            {
+                if (driver != null)
+                    return driver;
+
+                var screen = HoverTextScreen.Instance;
+                if (screen == null)
+                    return null;
+
+                driver = screen.gameObject.GetComponent<LateUpdateDriver>();
+                if (driver == null)
+                    driver = screen.gameObject.AddComponent<LateUpdateDriver>();
+
+                return driver;
+            }
+
+            private sealed class PendingLayout
+            {
+                private readonly Grid grid;
+                private readonly List<InfoCardWidgets> pendingCards = new();
+
+                public PendingLayout(Grid grid)
+                {
+                    this.grid = grid;
+                }
+
+                public bool IsFor(Grid other)
+                {
+                    return ReferenceEquals(grid, other);
+                }
+
+                public void ReplacePendingCards(List<InfoCardWidgets> cards)
+                {
+                    pendingCards.Clear();
+
+                    foreach (var card in cards)
+                    {
+                        if (card == null || pendingCards.Contains(card))
+                            continue;
+
+                        pendingCards.Add(card);
+                    }
+                }
+
+                public bool TryComplete()
+                {
+                    if (grid == null)
+                        return true;
+
+                    if (pendingCards.Count == 0)
+                    {
+                        grid.OnPendingCardsResolved();
+                        return true;
+                    }
+
+                    for (int i = pendingCards.Count - 1; i >= 0; i--)
+                    {
+                        var card = pendingCards[i];
+
+                        if (card == null)
+                        {
+                            pendingCards.RemoveAt(i);
+                            continue;
+                        }
+
+                        var state = card.ResolvePendingWidgets();
+
+                        if (state == InfoCardWidgets.PendingShadowBarState.Pending)
+                            continue;
+
+                        pendingCards.RemoveAt(i);
+                    }
+
+                    if (pendingCards.Count > 0)
+                        return false;
+
+                    grid.OnPendingCardsResolved();
+                    return true;
+                }
+            }
+
+            private sealed class LateUpdateDriver : MonoBehaviour
+            {
+                public void Activate()
+                {
+                    enabled = true;
+                }
+
+                private void OnEnable()
+                {
+                    if (pendingLayouts.Count == 0)
+                        enabled = false;
+                }
+
+                private void LateUpdate()
+                {
+                    Process();
+                }
             }
         }
     }

--- a/src/BetterInfoCards/Info/InfoCardWidgets.cs
+++ b/src/BetterInfoCards/Info/InfoCardWidgets.cs
@@ -9,7 +9,7 @@ namespace BetterInfoCards
 {
     public class InfoCardWidgets
     {
-        private enum PendingShadowBarState
+        internal enum PendingShadowBarState
         {
             None,
             Pending,
@@ -90,12 +90,12 @@ namespace BetterInfoCards
                 widgets.Add(rect);
         }
 
-        public void ResolvePendingWidgets()
+        public PendingShadowBarState ResolvePendingWidgets()
         {
-            ResolvePendingWidgets(scheduleDeferredChecks: true);
+            return ResolvePendingWidgets(scheduleDeferredChecks: true);
         }
 
-        private PendingShadowBarState ResolvePendingWidgets(bool scheduleDeferredChecks)
+        internal PendingShadowBarState ResolvePendingWidgets(bool scheduleDeferredChecks)
         {
             var state = UpdatePendingShadowBarState();
 


### PR DESCRIPTION
## Summary
- expose the InfoCard shadow bar resolution state so callers can distinguish pending widgets
- defer grid column measurement while cards are pending and reschedule layout once shadow bars size correctly
- add a late-update relayout path so the grid reapplies layout only after usable shadow bar dimensions are available

## Testing
- not run (container lacks the ONI/.NET runtime required for `dotnet` builds)

------
https://chatgpt.com/codex/tasks/task_e_68e2532394f08329b762b7c7973eab7f