### PR TITLE
Fix BetterInfoCards shadow bar resolution to use live widgets

### DIFF
--- a/ERRORS.md
+++ b/ERRORS.md
@@ -17,3 +17,9 @@
 - **Issue:** Shadow bar prefabs captured as components without a resolved `RectTransform` left `InfoCardWidgets.shadowBar` null, so exported cards reported zero width/height and never triggered column wrapping.
 - **Resolution:** Added prefab-based rect discovery with deferred retries so shadow bars resolve after Unity finishes layout, restoring non-zero dimensions for captured cards.
 - **Status:** Fixed
+
+## 2025-11-12 - BetterInfoCards shadow bar instance resolution
+- **Module:** BetterInfoCards hover widget capture
+- **Issue:** Resolving `shadowBar` from prefab assets caused layout translations and width adjustments to mutate the prefab instead of the live hover card instance, so later draws inherited stale offsets and asset changes persisted across sessions.
+- **Resolution:** Track pending widget entries and re-resolve the `RectTransform` from instantiated scene objects, falling back to hierarchy scans so deferred sizing now operates on the live hover card rather than the prefab asset.
+- **Status:** Fixed

--- a/NOTES.md
+++ b/NOTES.md
@@ -201,3 +201,8 @@
 - Updated `InfoCardWidgets.ResolvePendingWidgets` to expose the pending/resolved state so grid layout can detect when shadow bars are still sizing.
 - Reworked `Grid` to defer column measurement for pending cards, schedule a late-update relayout once the deferred resolver promotes them, and apply the final layout only after the shadow bar reports usable dimensions.
 - Unable to rebuild or run in-game validation because the container still lacks the ONI-managed assemblies and a `dotnet` runtime; maintainers should run `dotnet build src/oniMods.sln` locally and verify multi-column wrapping after the deferred pass completes.
+
+## 2025-11-12 - BetterInfoCards shadow bar instance resolution
+- Replaced the prefab-based `RectTransform` cache with live entry tracking so deferred resolution now probes instantiated hover card widgets before adjusting layout.
+- Updated the pending queues to store the captured entry alongside collapsed rects, ensuring late-update retries operate on scene objects and unregister once a usable rect is located.
+- Unable to rebuild or run in-game validation in this container because the ONI-managed assemblies and `dotnet` runtime remain unavailable; maintainers should run `dotnet build src/oniMods.sln` locally and hover a multi-widget card to confirm translations and width adjustments affect only the active instance.


### PR DESCRIPTION
## Summary
- update `InfoCardWidgets` to resolve shadow bar rects from live hover card entries and track pending candidates by instance
- ensure deferred shadow bar resolution operates on scene objects before layout adjustments and clears prefab fallbacks once resolved
- document the prefab mutation bug fix in `ERRORS.md` and `NOTES.md`
- align `PendingShadowBarState` accessibility with `ResolvePendingWidgets` so the enum can be returned by public callers

## Testing
- not run (ONI-managed assemblies and dotnet runtime are unavailable in this container)


------
https://chatgpt.com/codex/tasks/task_e_68e257dac2548329b00cbfd651ebd773