### PR TITLE
Reset widget capture outside intercept mode

### DIFF
--- a/src/BetterInfoCards/Export/ExportWidgets.cs
+++ b/src/BetterInfoCards/Export/ExportWidgets.cs
@@ -391,6 +391,7 @@ namespace BetterInfoCards.Export
         {
             static void Postfix()
             {
+                curICWidgets = null;
                 icWidgets.Clear();
             }
         }
@@ -418,14 +419,12 @@ namespace BetterInfoCards.Export
             if (prefab == null)
                 return;
 
-            if (curICWidgets == null)
-            {
-                if (InterceptHoverDrawer.IsInterceptMode)
-                    return;
+            if (InterceptHoverDrawer.IsInterceptMode)
+                return;
 
+            if (curICWidgets == null)
                 curICWidgets = new();
                 icWidgets.Add(curICWidgets);
-            }
 
             if (!ShouldProcessEntry(__result))
                 return;


### PR DESCRIPTION
## Summary
- reset the active info card widget container when a new draw cycle begins
- skip widget capture while hover drawer interception is active while keeping lazy allocation for replay export

## Testing
- not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e26b45d92c83298ddb955c42ffd5b7