### PR TITLE
Relax shadow bar prefab matching for wrappers

### DIFF
--- a/ERRORS.md
+++ b/ERRORS.md
@@ -23,3 +23,9 @@
 - **Issue:** Resolving `shadowBar` from prefab assets caused layout translations and width adjustments to mutate the prefab instead of the live hover card instance, so later draws inherited stale offsets and asset changes persisted across sessions.
 - **Resolution:** Track pending widget entries and re-resolve the `RectTransform` from instantiated scene objects, falling back to hierarchy scans so deferred sizing now operates on the live hover card rather than the prefab asset.
 - **Status:** Fixed
+
+## 2025-11-13 - BetterInfoCards wrapper shadow bar prefabs
+- **Module:** BetterInfoCards hover widget capture
+- **Issue:** Skin shadow bars wrapped in helper objects exposed extra components and differing rect sizes, so `InfoCardWidgets` rejected the prefab match and never promoted the instantiated shadow bar, leaving card widths and heights at zero.
+- **Resolution:** Relaxed the prefab comparison so wrappers that contain a component superset of the skin shadow bar still qualify, allowing the runtime `RectTransform` to be recovered from the entry hierarchy and restored to `shadowBar`.
+- **Status:** Fixed

--- a/NOTES.md
+++ b/NOTES.md
@@ -206,3 +206,8 @@
 - Replaced the prefab-based `RectTransform` cache with live entry tracking so deferred resolution now probes instantiated hover card widgets before adjusting layout.
 - Updated the pending queues to store the captured entry alongside collapsed rects, ensuring late-update retries operate on scene objects and unregister once a usable rect is located.
 - Unable to rebuild or run in-game validation in this container because the ONI-managed assemblies and `dotnet` runtime remain unavailable; maintainers should run `dotnet build src/oniMods.sln` locally and hover a multi-widget card to confirm translations and width adjustments affect only the active instance.
+
+## 2025-11-13 - BetterInfoCards shadow bar wrapper tolerance
+- Relaxed `InfoCardWidgets.MatchesWidgetPrefab` so helper wrappers that add components around the skin shadow bar still qualify via the existing component-superset fallback, allowing deferred prefab resolution to recover the instantiated `RectTransform` and repopulate `shadowBar`.
+- Verified the fallback continues to assign `shadowBar` through `TryResolveShadowBarFromPrefab`, ensuring downstream layout math sees non-zero widths/heights once the instantiated rect reports a usable size.
+- Unable to rebuild or execute in-game validation because the container lacks the ONI-managed assemblies and `dotnet` runtime; maintainers should run `dotnet build src/oniMods.sln` locally and confirm wrapped skin shadow bars now populate card dimensions.

--- a/src/BetterInfoCards/Info/InfoCardWidgets.cs
+++ b/src/BetterInfoCards/Info/InfoCardWidgets.cs
@@ -121,6 +121,9 @@ namespace BetterInfoCards
             if (string.Equals(StripCloneSuffix(candidate.name), StripCloneSuffix(reference.name), StringComparison.Ordinal))
                 return true;
 
+            if (HasComponentSuperset(candidate, reference))
+                return true;
+
             if (!HasMatchingComponents(candidate, reference))
                 return false;
 


### PR DESCRIPTION
## Summary
- allow InfoCardWidgets to match shadow bar prefabs that wrap the skin widget by accepting component supersets
- ensure the shadow bar fallback path keeps the runtime RectTransform assigned so layout math sees non-zero sizes
- record the wrapper-prefab fix in the maintenance logs

## Testing
- not run (environment lacks the ONI/.NET toolchain)


------
https://chatgpt.com/codex/tasks/task_e_68e27468d9f0832982ff470f6b3f7239