### PR TITLE
Guard widget export until hover drawer skin is ready

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -221,3 +221,8 @@
 - Hardened the temperature converter to reuse a cached `PrimaryElement` lookup, emit a one-time warning when the component is missing, and fall back to a safe default instead of dereferencing `null`.
 - Reviewed the existing title converter logging helper and mirrored its usage for temperature entries so missing-component spam stays suppressed after the first warning.
 - Compilation and in-game hover verification remain blocked in this environment due to missing ONI assemblies and `dotnet`; maintainers should run `dotnet build src/oniMods.sln` and hover affected buildings to confirm the hover card displays the fallback temperature text without crashing.
+
+## 2025-11-16 - BetterInfoCards hover drawer skin guard
+- Added a pre-export guard in `ExportWidgets.GetWidget_Postfix` so widget capture waits for `HoverTextDrawer.skin` to load before mutating per-card state, logging a single warning while the skin is unavailable.
+- Confirmed the intercept-mode short-circuit remains intact and the new guard clears its warning flag once the drawer skin becomes accessible so exports resume normally.
+- Unable to rebuild or validate in-game here because the container lacks the ONI-managed assemblies and a `dotnet` runtime; maintainers should run `dotnet build src/oniMods.sln` and confirm hover cards render without crashes while the drawer initialises, then resume widget export once the skin loads.

--- a/src/BetterInfoCards/Export/ExportWidgets.cs
+++ b/src/BetterInfoCards/Export/ExportWidgets.cs
@@ -13,6 +13,7 @@ namespace BetterInfoCards.Export
         private static Type widgetEntryType;
         private static readonly Dictionary<Type, MemberInfo> rectMemberCache = new();
         private static readonly object rectMemberCacheLock = new();
+        private static bool hoverDrawerSkinUnavailableLogged;
 
         static ExportWidgets()
         {
@@ -421,6 +422,24 @@ namespace BetterInfoCards.Export
 
             if (InterceptHoverDrawer.IsInterceptMode)
                 return;
+
+            var hoverTextScreen = HoverTextScreen.Instance;
+            var drawer = hoverTextScreen?.drawer;
+            var skin = drawer?.skin;
+
+            if (drawer == null || skin == null)
+            {
+                if (!hoverDrawerSkinUnavailableLogged)
+                {
+                    hoverDrawerSkinUnavailableLogged = true;
+                    Debug.LogWarning("[BetterInfoCards] HoverTextDrawer skin is unavailable; deferring widget export until initialization completes.");
+                }
+
+                return;
+            }
+
+            if (hoverDrawerSkinUnavailableLogged)
+                hoverDrawerSkinUnavailableLogged = false;
 
             if (curICWidgets == null)
             {


### PR DESCRIPTION
## Summary
- guard `ExportWidgets.GetWidget_Postfix` so widget export waits for the hover drawer skin to initialise and logs once while it is unavailable
- reset the warning flag once the skin appears and document the manual verification follow-up in `NOTES.md`

## Testing
- not run (container lacks ONI-managed assemblies and the .NET runtime)


------
https://chatgpt.com/codex/tasks/task_e_68e27ef86c608329b2fcfdaf7ebca1e6