### PR TITLE
Align FixedMod build props with shared configuration

### DIFF
--- a/FixedMod/src/Directory.Build.props
+++ b/FixedMod/src/Directory.Build.props
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <Import Project="../src/Directory.Build.props" />
+
+  <PropertyGroup>
+    <TranslationsFolder>..\..\..\Translations</TranslationsFolder>
+  </PropertyGroup>
+</Project>

--- a/FixedMod/src/Directory.Build.targets
+++ b/FixedMod/src/Directory.Build.targets
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <Import Project="../src/Directory.Build.targets" />
+</Project>

--- a/NOTES.md
+++ b/NOTES.md
@@ -251,3 +251,8 @@
 - Filtered the disease summary formatter so it skips invalid disease indices before requesting localized names, logging a single warning the first time an out-of-range entry appears.
 - This prevents `GameUtil.GetFormattedDiseaseName` from dereferencing an invalid index when polluted storage includes placeholder rows.
 - Rebuild and in-game tooltip verification remain outstanding; the hosted environment still lacks the ONI-managed assemblies and `dotnet` runtime, so maintainers need to run `dotnet build src/oniMods.sln` locally and hover affected storage to confirm the warning suppresses the crash.
+
+## 2025-11-22 - ContainerTooltips build import alignment
+- Added `FixedMod/src/Directory.Build.props` so the FixedMod solution inherits the shared net471 target, references, and translation path overrides.
+- Added `FixedMod/src/Directory.Build.targets` to ensure the packaging/versioning pipeline runs for ContainerTooltips when built from the FixedMod solution.
+- Unable to reload `src/oniMods.sln` or build `ContainerTooltips` here because the container lacks the required .NET/ONI toolchain; maintainers should run `dotnet build src/oniMods.sln` locally to confirm the shared settings apply without errors.


### PR DESCRIPTION
## Summary
- import the shared Directory.Build.props file so the FixedMod ContainerTooltips project inherits the net471 target and references
- point the FixedMod translations folder at the repository root and import the shared Directory.Build.targets for packaging tasks
- document the outstanding local build verification in NOTES.md

## Testing
- not run (dotnet is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e3c34b77488329b142e192e60829ee