### PR TITLE
Add Container Tooltips translation template

### DIFF
--- a/FixedMod/src/ContainerTooltips/Mod/STRINGS.cs
+++ b/FixedMod/src/ContainerTooltips/Mod/STRINGS.cs
@@ -1,0 +1,17 @@
+using AzeLib;
+
+namespace STRINGS
+{
+    public sealed class CONTAINERTOOLTIPS : AStrings<CONTAINERTOOLTIPS>
+    {
+        public sealed class STATUSITEMS
+        {
+            public sealed class CONTAINERTOOLTIPSTATUSITEM
+            {
+                public static LocString NAME = "Contents";
+                public static LocString TOOLTIP = "Shows the items in internal storage.";
+                public static LocString EMPTY = "None";
+            }
+        }
+    }
+}

--- a/FixedMod/src/ContainerTooltips/Mod/UserMod.cs
+++ b/FixedMod/src/ContainerTooltips/Mod/UserMod.cs
@@ -51,9 +51,21 @@ public sealed class UserMod : UserMod2
         if (ContentsStatusItem != null)
             return;
 
-        Strings.Add(new[] { NameStringKey, "Contents" });
-        Strings.Add(new[] { TooltipStringKey, "Shows the items in internal storage." });
-        Strings.Add(new[] { EmptyStringKey, "None" });
+        Strings.Add(new[]
+        {
+            NameStringKey,
+            global::STRINGS.CONTAINERTOOLTIPS.STATUSITEMS.CONTAINERTOOLTIPSTATUSITEM.NAME
+        });
+        Strings.Add(new[]
+        {
+            TooltipStringKey,
+            global::STRINGS.CONTAINERTOOLTIPS.STATUSITEMS.CONTAINERTOOLTIPSTATUSITEM.TOOLTIP
+        });
+        Strings.Add(new[]
+        {
+            EmptyStringKey,
+            global::STRINGS.CONTAINERTOOLTIPS.STATUSITEMS.CONTAINERTOOLTIPSTATUSITEM.EMPTY
+        });
 
         ContentsStatusItem = new StatusItem(
             StatusItemId,

--- a/Translations/ContainerTooltips/README.md
+++ b/Translations/ContainerTooltips/README.md
@@ -1,3 +1,10 @@
 # Container Tooltips Translations
 
-This folder hosts `.po` files for the Container Tooltips mod. Add new translations by copying `_template.pot` once it is generated during the localization build.
+This folder hosts `.po` files for the Container Tooltips mod. A ready-to-use `_template.pot` is checked in and includes entries for the status item name, tooltip, and empty-state text exposed by the mod.
+
+To start a translation:
+
+1. Copy `_template.pot` to a new file named after the locale (for example, `es.po`).
+2. Translate the `msgid` values while keeping the `msgctxt` keys intact so the game can load the strings.
+
+The English source strings live in `UserMod.InitializeStatusItem` and are also registered through the `STRINGS.CONTAINERTOOLTIPS` class so AzeLib’s POT generation (available in debug builds) will recreate the same keys automatically when new strings are added. If new strings are introduced, regenerate the template in a debug build or update `_template.pot` manually to keep it in sync.

--- a/Translations/ContainerTooltips/_template.pot
+++ b/Translations/ContainerTooltips/_template.pot
@@ -1,0 +1,16 @@
+msgid ""
+msgstr ""
+"Application: Oxygen Not Included"
+"POT Version: 2.0"
+
+msgctxt "STRINGS.CONTAINERTOOLTIPS.STATUSITEMS.CONTAINERTOOLTIPSTATUSITEM.NAME"
+msgid "Contents"
+msgstr ""
+
+msgctxt "STRINGS.CONTAINERTOOLTIPS.STATUSITEMS.CONTAINERTOOLTIPSTATUSITEM.TOOLTIP"
+msgid "Shows the items in internal storage."
+msgstr ""
+
+msgctxt "STRINGS.CONTAINERTOOLTIPS.STATUSITEMS.CONTAINERTOOLTIPSTATUSITEM.EMPTY"
+msgid "None"
+msgstr ""


### PR DESCRIPTION
## Summary
- add AzeLib string registration for the Container Tooltips status item texts
- introduce a checked-in `_template.pot` for the Container Tooltips translation set
- document the template for translators in the Container Tooltips README

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e3c3e8792c8329bcacf2b09395cedf