### PR TITLE
Fix ContainerTooltips FixedMod build imports

### DIFF
--- a/ERRORS.md
+++ b/ERRORS.md
@@ -35,3 +35,9 @@
 - **Issue:** Buildings without a `PrimaryElement` caused the temperature converter to dereference `null` while reading `Temperature`, crashing hover card rendering.
 - **Resolution:** Cache the component lookup, emit a one-shot warning when it is missing, and return a safe default so aggregation proceeds without throwing.
 - **Status:** Fixed
+
+## 2025-11-23 - ContainerTooltips build imports
+- **Module:** ContainerTooltips project configuration
+- **Issue:** The FixedMod-specific `Directory.Build.props` and `.targets` imported `../src/...`, which resolved to the same directory and caused MSBuild to report a circular dependency when the solution loaded in Visual Studio.
+- **Resolution:** Updated the relative paths to `../../src/...` so the FixedMod projects now import the shared root build settings without recursion.
+- **Status:** Fixed

--- a/FixedMod/src/Directory.Build.props
+++ b/FixedMod/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
-  <Import Project="../src/Directory.Build.props" />
+  <Import Project="../../src/Directory.Build.props" />
 
   <PropertyGroup>
     <TranslationsFolder>..\..\..\Translations</TranslationsFolder>

--- a/FixedMod/src/Directory.Build.targets
+++ b/FixedMod/src/Directory.Build.targets
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
-  <Import Project="../src/Directory.Build.targets" />
+  <Import Project="../../src/Directory.Build.targets" />
 </Project>

--- a/NOTES.md
+++ b/NOTES.md
@@ -256,3 +256,7 @@
 - Added `FixedMod/src/Directory.Build.props` so the FixedMod solution inherits the shared net471 target, references, and translation path overrides.
 - Added `FixedMod/src/Directory.Build.targets` to ensure the packaging/versioning pipeline runs for ContainerTooltips when built from the FixedMod solution.
 - Unable to reload `src/oniMods.sln` or build `ContainerTooltips` here because the container lacks the required .NET/ONI toolchain; maintainers should run `dotnet build src/oniMods.sln` locally to confirm the shared settings apply without errors.
+
+## 2025-11-23 - ContainerTooltips import path fix
+- Corrected the relative imports in `FixedMod/src/Directory.Build.props` and `FixedMod/src/Directory.Build.targets` to reference the root `src` directory instead of the FixedMod subtree, eliminating the circular dependency Visual Studio reported when loading the project.
+- Build verification remains pending; the hosted environment still lacks the ONI-managed assemblies and `.NET` runtime, so maintainers should run `dotnet build src/oniMods.sln` locally to confirm the solution now loads without the circular import error.


### PR DESCRIPTION
## Summary
- point the FixedMod Directory.Build props/targets to the root src folder so Visual Studio no longer reports a circular import
- document the circular import fix in the shared NOTES and ERRORS logs for future maintainers

## Testing
- not run (environment lacks the ONI/.NET toolchain)

------
https://chatgpt.com/codex/tasks/task_e_68e3b49617008329acf51acffa05844e