### PR TITLE
Fix ContainerTooltips AzeLib project reference

### DIFF
--- a/FixedMod/src/Directory.Build.props
+++ b/FixedMod/src/Directory.Build.props
@@ -4,5 +4,10 @@
 
   <PropertyGroup>
     <TranslationsFolder>..\..\..\Translations</TranslationsFolder>
+    <UsesAzeLib>false</UsesAzeLib>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\AzeLib\AzeLib.csproj" Private="true" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- disable the inherited UsesAzeLib flag for FixedMod so MSBuild stops probing for a local copy
- add an explicit project reference to the root AzeLib.csproj for ContainerTooltips builds

## Testing
- not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e3d3809ef48329abac43ad4fe473b8