### PR TITLE
Adjust FixedMod props import order

### DIFF
--- a/FixedMod/src/Directory.Build.props
+++ b/FixedMod/src/Directory.Build.props
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
-  <Import Project="../../src/Directory.Build.props" />
-
   <PropertyGroup>
     <TranslationsFolder>..\..\..\Translations</TranslationsFolder>
     <UsesAzeLib>false</UsesAzeLib>
   </PropertyGroup>
+
+  <Import Project="../../src/Directory.Build.props" />
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\AzeLib\AzeLib.csproj" Private="true" />


### PR DESCRIPTION
## Summary
- move the FixedMod `UsesAzeLib` property group before the shared props import so the override applies during evaluation
- retain the explicit AzeLib project reference for ContainerTooltips

## Testing
- not run (solution reload unavailable in container environment)


------
https://chatgpt.com/codex/tasks/task_e_68e3daf5e69c83299513e4841a9b72d2