### PR TITLE
Align FixedMod Directory.Build props paths

### DIFF
--- a/FixedMod/src/Directory.Build.props
+++ b/FixedMod/src/Directory.Build.props
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <TranslationsFolder>..\..\..\Translations</TranslationsFolder>
+    <TranslationsFolder>..\..\Translations</TranslationsFolder>
     <UsesAzeLib>false</UsesAzeLib>
   </PropertyGroup>
 
   <Import Project="../../src/Directory.Build.props" />
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\AzeLib\AzeLib.csproj" Private="true" />
+    <ProjectReference Include="..\..\src\AzeLib\AzeLib.csproj" Private="true" />
   </ItemGroup>
 </Project>

--- a/NOTES.md
+++ b/NOTES.md
@@ -260,3 +260,8 @@
 ## 2025-11-23 - ContainerTooltips import path fix
 - Corrected the relative imports in `FixedMod/src/Directory.Build.props` and `FixedMod/src/Directory.Build.targets` to reference the root `src` directory instead of the FixedMod subtree, eliminating the circular dependency Visual Studio reported when loading the project.
 - Build verification remains pending; the hosted environment still lacks the ONI-managed assemblies and `.NET` runtime, so maintainers should run `dotnet build src/oniMods.sln` locally to confirm the solution now loads without the circular import error.
+
+## 2025-11-24 - ContainerTooltips translation path and AzeLib reference
+- Updated `FixedMod/src/Directory.Build.props` so the translations path points at the repository-level `Translations` directory, matching the packaging expectations.
+- Adjusted the `AzeLib` project reference to target the shared source tree while keeping the reference private so ContainerTooltips links against the library without redistributing its binaries.
+- Could not re-run `msbuild /t:Restore` or reload the solution here because the container still lacks `dotnet`/MSBuild (`bash: command not found: dotnet`); maintainers should restore the solution locally to confirm the reference resolves.


### PR DESCRIPTION
## Summary
- point the FixedMod translation folder at the repository-level `Translations` directory so packaging picks up shared strings
- retarget the ContainerTooltips `AzeLib` project reference to the shared `src` tree while keeping the dependency private
- document the path updates and missing local restore capability in `NOTES.md` per the Maintainer Playbook

## Testing
- not run (container lacks dotnet/msbuild as noted in the Maintainer Playbook)


------
https://chatgpt.com/codex/tasks/task_e_68e3ddaad4808329ada2836ee4d7ebde