### PR TITLE
Stop ContainerTooltips from depending on AzeLib

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -265,3 +265,8 @@
 - Updated `FixedMod/src/Directory.Build.props` so the translations path points at the repository-level `Translations` directory, matching the packaging expectations.
 - Adjusted the `AzeLib` project reference to target the shared source tree while keeping the reference private so ContainerTooltips links against the library without redistributing its binaries.
 - Could not re-run `msbuild /t:Restore` or reload the solution here because the container still lacks `dotnet`/MSBuild (`bash: command not found: dotnet`); maintainers should restore the solution locally to confirm the reference resolves.
+
+## 2025-11-25 - ContainerTooltips AzeLib dependency removal
+- Converted `STRINGS.CONTAINERTOOLTIPS` into a static container and manually register the status item strings during initialization so the mod no longer depends on AzeLib's reflection-based registration.
+- Marked the project with `<UsesAzeLib>false</UsesAzeLib>` to drop the inherited project reference now that no AzeLib types are required.
+- The workspace still lacks the ONI-managed assemblies and `.NET` runtime, so I was unable to run `dotnet build src/oniMods.sln`; maintainers should rebuild locally to confirm ContainerTooltips compiles cleanly without AzeLib.

--- a/src/ContainerTooltips/ContainerTooltips.csproj
+++ b/src/ContainerTooltips/ContainerTooltips.csproj
@@ -8,4 +8,7 @@
     <Title>Container Tooltips</Title>
     <Description>Displays the contents of storage components directly in their status items and tooltips.</Description>
   </PropertyGroup>
+  <PropertyGroup>
+    <UsesAzeLib>false</UsesAzeLib>
+  </PropertyGroup>
 </Project>

--- a/src/ContainerTooltips/Mod/STRINGS.cs
+++ b/src/ContainerTooltips/Mod/STRINGS.cs
@@ -1,12 +1,10 @@
-using AzeLib;
-
 namespace STRINGS
 {
-    public sealed class CONTAINERTOOLTIPS : AStrings<CONTAINERTOOLTIPS>
+    public static class CONTAINERTOOLTIPS
     {
-        public sealed class STATUSITEMS
+        public static class STATUSITEMS
         {
-            public sealed class CONTAINERTOOLTIPSTATUSITEM
+            public static class CONTAINERTOOLTIPSTATUSITEM
             {
                 public static LocString NAME = "Contents";
                 public static LocString TOOLTIP = "Shows the items in internal storage.";

--- a/src/ContainerTooltips/Mod/UserMod.cs
+++ b/src/ContainerTooltips/Mod/UserMod.cs
@@ -51,21 +51,9 @@ public sealed class UserMod : UserMod2
         if (ContentsStatusItem != null)
             return;
 
-        Strings.Add(new[]
-        {
-            NameStringKey,
-            global::STRINGS.CONTAINERTOOLTIPS.STATUSITEMS.CONTAINERTOOLTIPSTATUSITEM.NAME
-        });
-        Strings.Add(new[]
-        {
-            TooltipStringKey,
-            global::STRINGS.CONTAINERTOOLTIPS.STATUSITEMS.CONTAINERTOOLTIPSTATUSITEM.TOOLTIP
-        });
-        Strings.Add(new[]
-        {
-            EmptyStringKey,
-            global::STRINGS.CONTAINERTOOLTIPS.STATUSITEMS.CONTAINERTOOLTIPSTATUSITEM.EMPTY
-        });
+        RegisterString(NameStringKey, global::STRINGS.CONTAINERTOOLTIPS.STATUSITEMS.CONTAINERTOOLTIPSTATUSITEM.NAME);
+        RegisterString(TooltipStringKey, global::STRINGS.CONTAINERTOOLTIPS.STATUSITEMS.CONTAINERTOOLTIPSTATUSITEM.TOOLTIP);
+        RegisterString(EmptyStringKey, global::STRINGS.CONTAINERTOOLTIPS.STATUSITEMS.CONTAINERTOOLTIPSTATUSITEM.EMPTY);
 
         ContentsStatusItem = new StatusItem(
             StatusItemId,
@@ -146,5 +134,15 @@ public sealed class UserMod : UserMod2
     private static bool IsSameTick(float left, float right)
     {
         return !float.IsNaN(left) && !float.IsNaN(right) && Mathf.Approximately(left, right);
+    }
+
+    private static void RegisterString(string key, LocString value)
+    {
+        var englishText = value.String;
+
+        if (string.IsNullOrEmpty(englishText))
+            englishText = value.ToString();
+
+        Strings.Add(new[] { key, englishText });
     }
 }


### PR DESCRIPTION
## Summary
- convert the ContainerTooltips string definitions into a static hierarchy and keep the status item loc strings
- manually register the status item strings during initialization and drop the implicit AzeLib dependency
- mark the project as not using AzeLib and document the missing build tooling

## Testing
- dotnet build src/oniMods.sln *(fails: `dotnet` is not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3e7f70c0483299545378bc82c67a0