### PR TITLE
Fix ContainerTooltips storage namespace collision

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -270,3 +270,8 @@
 - Converted `STRINGS.CONTAINERTOOLTIPS` into a static container and manually register the status item strings during initialization so the mod no longer depends on AzeLib's reflection-based registration.
 - Marked the project with `<UsesAzeLib>false</UsesAzeLib>` to drop the inherited project reference now that no AzeLib types are required.
 - The workspace still lacks the ONI-managed assemblies and `.NET` runtime, so I was unable to run `dotnet build src/oniMods.sln`; maintainers should rebuild locally to confirm ContainerTooltips compiles cleanly without AzeLib.
+
+## 2025-11-26 - ContainerTooltips namespace collision fix
+- Renamed the ContainerTooltips storage component namespace to `BadMod.ContainerTooltips.Components` so it no longer conflicts with ONI's `Storage` type.
+- Updated the mod entry point and Harmony patch to import the new namespace.
+- `dotnet` remains unavailable in this workspace, preventing a rebuild; maintainers should run `dotnet build src/oniMods.sln` locally to confirm the namespace/type resolution succeeds.

--- a/src/ContainerTooltips/Mod/UserMod.cs
+++ b/src/ContainerTooltips/Mod/UserMod.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using BadMod.ContainerTooltips.Configuration;
-using BadMod.ContainerTooltips.Storage;
+using BadMod.ContainerTooltips.Components;
 using HarmonyLib;
 using Klei.AI;
 using KMod;

--- a/src/ContainerTooltips/Patches/StorageOnSpawnPatch.cs
+++ b/src/ContainerTooltips/Patches/StorageOnSpawnPatch.cs
@@ -1,4 +1,4 @@
-using BadMod.ContainerTooltips.Storage;
+using BadMod.ContainerTooltips.Components;
 using HarmonyLib;
 using UnityEngine;
 

--- a/src/ContainerTooltips/Storage/StorageContentsBehaviour.cs
+++ b/src/ContainerTooltips/Storage/StorageContentsBehaviour.cs
@@ -3,7 +3,7 @@ using BadMod.ContainerTooltips.Mod;
 using Klei.AI;
 using UnityEngine;
 
-namespace BadMod.ContainerTooltips.Storage;
+namespace BadMod.ContainerTooltips.Components;
 
 public sealed class StorageContentsBehaviour : KMonoBehaviour
 {

--- a/src/ContainerTooltips/Storage/StorageContentsSummarizer.cs
+++ b/src/ContainerTooltips/Storage/StorageContentsSummarizer.cs
@@ -6,7 +6,7 @@ using BadMod.ContainerTooltips.Configuration;
 using BadMod.ContainerTooltips.Enums;
 using UnityEngine;
 
-namespace BadMod.ContainerTooltips.Storage;
+namespace BadMod.ContainerTooltips.Components;
 
 internal static class StorageContentsSummarizer
 {


### PR DESCRIPTION
## Summary
- rename the ContainerTooltips storage component namespace to `BadMod.ContainerTooltips.Components`
- update the mod entry point and Storage.OnSpawn Harmony patch to import the new namespace
- document the namespace change and outstanding build verification in NOTES.md

## Testing
- dotnet build src/oniMods.sln *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3fdc21dc483299a5532274d5ee5c8