### PR TITLE
Fix ContainerTooltips namespace imports

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -275,3 +275,7 @@
 - Renamed the ContainerTooltips storage component namespace to `BadMod.ContainerTooltips.Components` so it no longer conflicts with ONI's `Storage` type.
 - Updated the mod entry point and Harmony patch to import the new namespace.
 - `dotnet` remains unavailable in this workspace, preventing a rebuild; maintainers should run `dotnet build src/oniMods.sln` locally to confirm the namespace/type resolution succeeds.
+
+## 2025-11-27 - ContainerTooltips missing type imports
+- Added the missing `Klei`, `Klei.AI`, and `Database` namespace imports so `LocString`, `Tag`, `Db`, and related types resolve without relying on implicit references.
+- The container still lacks the ONI-managed assemblies and `.NET` runtime, so `dotnet build src/oniMods.sln` cannot be executed here; maintainers should rebuild locally to confirm the project compiles with the restored imports.

--- a/src/ContainerTooltips/Mod/STRINGS.cs
+++ b/src/ContainerTooltips/Mod/STRINGS.cs
@@ -1,3 +1,5 @@
+using Klei;
+
 namespace STRINGS
 {
     public static class CONTAINERTOOLTIPS

--- a/src/ContainerTooltips/Mod/UserMod.cs
+++ b/src/ContainerTooltips/Mod/UserMod.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using BadMod.ContainerTooltips.Configuration;
 using BadMod.ContainerTooltips.Components;
 using HarmonyLib;
+using Klei;
 using Klei.AI;
 using KMod;
 using PeterHan.PLib.Core;

--- a/src/ContainerTooltips/Patches/DatabaseInitializePatch.cs
+++ b/src/ContainerTooltips/Patches/DatabaseInitializePatch.cs
@@ -1,4 +1,5 @@
 using BadMod.ContainerTooltips.Mod;
+using Database;
 using HarmonyLib;
 using UnityEngine;
 

--- a/src/ContainerTooltips/Storage/StorageContentsSummarizer.cs
+++ b/src/ContainerTooltips/Storage/StorageContentsSummarizer.cs
@@ -4,6 +4,9 @@ using System.Linq;
 using System.Text;
 using BadMod.ContainerTooltips.Configuration;
 using BadMod.ContainerTooltips.Enums;
+using Database;
+using Klei;
+using Klei.AI;
 using UnityEngine;
 
 namespace BadMod.ContainerTooltips.Components;


### PR DESCRIPTION
## Summary
- add missing Klei and Database usings so ContainerTooltips resolves LocString, Tag, Db, and related types
- record the import fix and blocked build in NOTES.md for maintainer follow-up

## Testing
- `dotnet build src/oniMods.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68e4025320348329ba0ed731e8821e3a