### PR TITLE
Fix ContainerTooltips mass format alias

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -279,3 +279,7 @@
 ## 2025-11-27 - ContainerTooltips missing type imports
 - Added the missing `Klei`, `Klei.AI`, and `Database` namespace imports so `LocString`, `Tag`, `Db`, and related types resolve without relying on implicit references.
 - The container still lacks the ONI-managed assemblies and `.NET` runtime, so `dotnet build src/oniMods.sln` cannot be executed here; maintainers should rebuild locally to confirm the project compiles with the restored imports.
+
+## 2025-11-28 - ContainerTooltips mass format alias cleanup
+- Updated `MassDisplayMode` to use a uniquely named alias for `global::GameUtil` so ContainerTooltips no longer collides with other `GameUtil` aliases when loaded alongside mods.
+- The workspace still lacks the ONI-managed assemblies and `.NET` runtime, preventing a rebuild; maintainers should run `dotnet build src/oniMods.sln` locally to confirm the enum resolves without namespace conflicts.

--- a/src/ContainerTooltips/Enums/MassDisplayMode.cs
+++ b/src/ContainerTooltips/Enums/MassDisplayMode.cs
@@ -1,4 +1,4 @@
-using GameUtil = global::GameUtil;
+using OniGameUtil = global::GameUtil;
 
 namespace BadMod.ContainerTooltips.Enums;
 
@@ -7,8 +7,8 @@ namespace BadMod.ContainerTooltips.Enums;
 /// </summary>
 public enum MassDisplayMode
 {
-    Default = (int)GameUtil.MetricMassFormat.UseThreshold,
-    Kilogram = (int)GameUtil.MetricMassFormat.Kilogram,
-    Gram = (int)GameUtil.MetricMassFormat.Gram,
-    Tonne = (int)GameUtil.MetricMassFormat.Tonne
+    Default = (int)OniGameUtil.MetricMassFormat.UseThreshold,
+    Kilogram = (int)OniGameUtil.MetricMassFormat.Kilogram,
+    Gram = (int)OniGameUtil.MetricMassFormat.Gram,
+    Tonne = (int)OniGameUtil.MetricMassFormat.Tonne
 }


### PR DESCRIPTION
## Summary
- rename the GameUtil alias in ContainerTooltips' MassDisplayMode enum to a unique OniGameUtil alias
- update the enum values to reference the new alias
- document the outstanding build validation in NOTES.md

## Testing
- not run (dotnet tooling is unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e40400ea40832992a9d72e2fce68c9