### PR TITLE
Fix Storage OnSpawn patch accessibility

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -283,3 +283,7 @@
 ## 2025-11-28 - ContainerTooltips mass format alias cleanup
 - Updated `MassDisplayMode` to use a uniquely named alias for `global::GameUtil` so ContainerTooltips no longer collides with other `GameUtil` aliases when loaded alongside mods.
 - The workspace still lacks the ONI-managed assemblies and `.NET` runtime, preventing a rebuild; maintainers should run `dotnet build src/oniMods.sln` locally to confirm the enum resolves without namespace conflicts.
+
+## 2025-11-29 - ContainerTooltips Storage.OnSpawn patch accessibility
+- Replaced the `nameof(Storage.OnSpawn)` Harmony target with a literal string to avoid accessibility errors when the nested `OnSpawn` reference is unavailable at compile time.
+- Attempted to rebuild via `dotnet build src/ContainerTooltips/ContainerTooltips.csproj`, but the container still lacks the `.NET` host (`dotnet` command not found); maintainers should rebuild locally to confirm the accessibility warning no longer occurs.

--- a/src/ContainerTooltips/Patches/StorageOnSpawnPatch.cs
+++ b/src/ContainerTooltips/Patches/StorageOnSpawnPatch.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace BadMod.ContainerTooltips.Patches;
 
-[HarmonyPatch(typeof(Storage), nameof(Storage.OnSpawn))]
+[HarmonyPatch(typeof(Storage), "OnSpawn")]
 public static class StorageOnSpawnPatch
 {
     private static void Postfix(Storage __instance)


### PR DESCRIPTION
## Summary
- replace the ContainerTooltips Storage.OnSpawn Harmony patch to use a literal method name and avoid accessibility issues
- document the change and the blocked rebuild attempt in NOTES.md

## Testing
- dotnet build src/ContainerTooltips/ContainerTooltips.csproj *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e405f361e483299cd1fd5b14ae8790