### PR TITLE
Enable nullable analysis for ContainerTooltips

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -287,3 +287,7 @@
 ## 2025-11-29 - ContainerTooltips Storage.OnSpawn patch accessibility
 - Replaced the `nameof(Storage.OnSpawn)` Harmony target with a literal string to avoid accessibility errors when the nested `OnSpawn` reference is unavailable at compile time.
 - Attempted to rebuild via `dotnet build src/ContainerTooltips/ContainerTooltips.csproj`, but the container still lacks the `.NET` host (`dotnet` command not found); maintainers should rebuild locally to confirm the accessibility warning no longer occurs.
+
+## 2025-11-30 - ContainerTooltips nullable annotations context
+- Enabled nullable reference type analysis in `ContainerTooltips.csproj` so the compiler interprets existing `?` annotations and reports nullability issues correctly.
+- Unable to run `dotnet build src/ContainerTooltips/ContainerTooltips.csproj` here because the workspace still lacks the `.NET` runtime; maintainers should rebuild locally to confirm the nullability warnings disappear.

--- a/src/ContainerTooltips/ContainerTooltips.csproj
+++ b/src/ContainerTooltips/ContainerTooltips.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <AssemblyTitle>ContainerTooltips</AssemblyTitle>
     <RootNamespace>BadMod.ContainerTooltips</RootNamespace>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
     <Title>Container Tooltips</Title>


### PR DESCRIPTION
## Summary
- enable nullable reference type analysis for ContainerTooltips so existing annotations are respected
- document the outstanding rebuild requirement in NOTES.md since the hosted environment still lacks the .NET toolchain

## Testing
- dotnet build src/ContainerTooltips/ContainerTooltips.csproj *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e40708cf288329a1ee7b54cc8bf4d7