### PR TITLE
Fix ContainerTooltips status icon enum reference

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -291,3 +291,7 @@
 ## 2025-11-30 - ContainerTooltips nullable annotations context
 - Enabled nullable reference type analysis in `ContainerTooltips.csproj` so the compiler interprets existing `?` annotations and reports nullability issues correctly.
 - Unable to run `dotnet build src/ContainerTooltips/ContainerTooltips.csproj` here because the workspace still lacks the `.NET` runtime; maintainers should rebuild locally to confirm the nullability warnings disappear.
+
+## 2025-12-01 - ContainerTooltips status icon namespace
+- Updated `UserMod.InitializeStatusItem` to reference `StatusItem.IconType.Info` explicitly so the compiler resolves the nested enum without relying on an implicit `using`.
+- Attempted to run `dotnet build src/oniMods.sln`, but the container still lacks the `.NET` toolchain (`command not found: dotnet`); maintainers need to rebuild locally to confirm the enum reference compiles cleanly.

--- a/src/ContainerTooltips/Mod/UserMod.cs
+++ b/src/ContainerTooltips/Mod/UserMod.cs
@@ -60,7 +60,7 @@ public sealed class UserMod : UserMod2
             StatusItemId,
             ModStringsPrefix,
             "status_item_info",
-            IconType.Info,
+            StatusItem.IconType.Info,
             NotificationType.Neutral,
             allowMultiples: false,
             OverlayModes.None.ID)


### PR DESCRIPTION
## Summary
- reference `StatusItem.IconType.Info` explicitly when creating the ContainerTooltips status item so the compiler resolves the nested enum without implicit aliases
- record the namespace fix and lack of local toolchain in `NOTES.md` for follow-up maintainers

## Testing
- `dotnet build src/oniMods.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68e4096150dc83298911d2deb2cd60e0