### PR TITLE
Align ContainerTooltips status item constructor arguments

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -295,3 +295,7 @@
 ## 2025-12-01 - ContainerTooltips status icon namespace
 - Updated `UserMod.InitializeStatusItem` to reference `StatusItem.IconType.Info` explicitly so the compiler resolves the nested enum without relying on an implicit `using`.
 - Attempted to run `dotnet build src/oniMods.sln`, but the container still lacks the `.NET` toolchain (`command not found: dotnet`); maintainers need to rebuild locally to confirm the enum reference compiles cleanly.
+
+## 2025-11-05 - ContainerTooltips status item argument alignment
+- Swapped the named `allowMultiples` argument in `UserMod.InitializeStatusItem` for the positional boolean used by the upstream reference so the constructor overload resolves during compilation.
+- Unable to run `dotnet build src/oniMods.sln` here because the container lacks the .NET host and ONI-managed assemblies; maintainers should rebuild locally to confirm the status item now compiles without overload ambiguity.

--- a/src/ContainerTooltips/Mod/UserMod.cs
+++ b/src/ContainerTooltips/Mod/UserMod.cs
@@ -62,7 +62,7 @@ public sealed class UserMod : UserMod2
             "status_item_info",
             StatusItem.IconType.Info,
             NotificationType.Neutral,
-            allowMultiples: false,
+            false,
             OverlayModes.None.ID)
         {
             resolveStringCallback = ResolveStatusText,


### PR DESCRIPTION
## Summary
- replace the named allowMultiples argument in ContainerTooltips' StatusItem creation with the positional boolean used by the reference implementation so the constructor overload resolves
- document the change and the hosted build limitation in NOTES.md

## Testing
- dotnet build src/oniMods.sln *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68e40a11a6208329a1a9955c8978eda0