### PR TITLE
Fix ContainerTooltips status fallback lookup

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -300,6 +300,10 @@
 - Updated `UserMod.RegisterString` to rely on `LocString.ToString()` with a `value.text` fallback so the method no longer references the removed `LocString.String` member.
 - Unable to execute `dotnet build src/oniMods.sln` because the container still reports `command not found: dotnet`; please rebuild locally to confirm the updated LocString conversion compiles with the ONI toolchain.
 
+## 2025-12-03 - ContainerTooltips localized status fallback
+- Added a helper to resolve localized status item strings with a bundled fallback so overridden translations no longer regress to `MISSING:` when the string table lacks entries.
+- Unable to run `dotnet build src/oniMods.sln` or launch ONI in this environment (`dotnet` is unavailable and the game executable is not installed); maintainers should rebuild and verify in-game that storage bins now display the localized "Contents:" header.
+
 ## 2025-11-05 - ContainerTooltips status item argument alignment
 - Swapped the named `allowMultiples` argument in `UserMod.InitializeStatusItem` for the positional boolean used by the upstream reference so the constructor overload resolves during compilation.
 - Unable to run `dotnet build src/oniMods.sln` here because the container lacks the .NET host and ONI-managed assemblies; maintainers should rebuild locally to confirm the status item now compiles without overload ambiguity.

--- a/src/ContainerTooltips/Mod/UserMod.cs
+++ b/src/ContainerTooltips/Mod/UserMod.cs
@@ -101,8 +101,8 @@ public sealed class UserMod : UserMod2
             return cached.Result;
 
         var summary = StorageContentsSummarizer.SummarizeStorageContents(storage, Options.Instance.StatusLineLimit);
-        var header = Strings.Get(NameStringKey).String;
-        var empty = Strings.Get(EmptyStringKey).String;
+        var header = GetStringWithFallback(NameStringKey, global::STRINGS.CONTAINERTOOLTIPS.STATUSITEMS.CONTAINERTOOLTIPSTATUSITEM.NAME);
+        var empty = GetStringWithFallback(EmptyStringKey, global::STRINGS.CONTAINERTOOLTIPS.STATUSITEMS.CONTAINERTOOLTIPSTATUSITEM.EMPTY);
         var result = string.Concat(header, ": ", string.IsNullOrEmpty(summary) ? empty : summary);
 
         StatusTextCache[instanceId] = new SummaryCacheEntry(tick, result);
@@ -124,12 +124,25 @@ public sealed class UserMod : UserMod2
             return cached.Result;
 
         var summary = StorageContentsSummarizer.SummarizeStorageContents(storage, Options.Instance.TooltipLineLimit);
-        var header = Strings.Get(NameStringKey).String;
-        var empty = Strings.Get(EmptyStringKey).String;
+        var header = GetStringWithFallback(NameStringKey, global::STRINGS.CONTAINERTOOLTIPS.STATUSITEMS.CONTAINERTOOLTIPSTATUSITEM.NAME);
+        var empty = GetStringWithFallback(EmptyStringKey, global::STRINGS.CONTAINERTOOLTIPS.STATUSITEMS.CONTAINERTOOLTIPSTATUSITEM.EMPTY);
         var result = string.Concat(header, ": ", string.IsNullOrEmpty(summary) ? empty : summary);
 
         TooltipTextCache[instanceId] = new SummaryCacheEntry(tick, result);
         return result;
+    }
+
+    private static string GetStringWithFallback(string key, LocString fallback)
+    {
+        if (Strings.TryGet(key, out var entry))
+        {
+            var value = entry.String;
+
+            if (!string.IsNullOrEmpty(value))
+                return value;
+        }
+
+        return GetLocStringText(fallback);
     }
 
     private static bool IsSameTick(float left, float right)
@@ -137,13 +150,18 @@ public sealed class UserMod : UserMod2
         return !float.IsNaN(left) && !float.IsNaN(right) && Mathf.Approximately(left, right);
     }
 
-    private static void RegisterString(string key, LocString value)
+    private static string GetLocStringText(LocString value)
     {
         var englishText = value.ToString();
 
         if (string.IsNullOrEmpty(englishText))
             englishText = value.text ?? string.Empty;
 
-        Strings.Add(new[] { key, englishText });
+        return englishText;
+    }
+
+    private static void RegisterString(string key, LocString value)
+    {
+        Strings.Add(new[] { key, GetLocStringText(value) });
     }
 }


### PR DESCRIPTION
## Summary
- add a shared helper that resolves ContainerTooltips status strings via Strings.TryGet with a bundled fallback
- reuse the helper for status and tooltip text so translated overrides no longer show `MISSING:`
- document the change and the need for external validation in NOTES.md

## Testing
- not run (dotnet build src/oniMods.sln) *(tooling unavailable in container)*
- not run (manual ONI verification) *(game executable not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4164dbbf883299ac8603d2ad4fc4d