### PR TITLE
Adjust LocString fallback for container tooltip

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -311,3 +311,7 @@
 ## 2025-12-04 - ContainerTooltips missing string sentinel guard
 - Updated `UserMod.GetStringWithFallback` to ignore ONI's `MISSING` sentinel when localized lookups fail so the status line and tooltip fall back to the bundled `LocString` text.
 - `dotnet` and the ONI-managed assemblies are unavailable in this workspace, preventing a rebuild or in-game verification; maintainers should compile `ContainerTooltips` locally and confirm the "Contents:" header renders without the placeholder string.
+
+## 2025-12-05 - ContainerTooltips LocString text precedence
+- Adjusted `UserMod.GetLocStringText` to prefer the embedded `LocString.text` over `ToString()` so the default "Contents"/"None" registration values win when translations are missing.
+- `dotnet` remains unavailable in this environment, so `dotnet build src/oniMods.sln` could not be executed. In-game verification of the updated storage tooltip header should be performed locally.

--- a/src/ContainerTooltips/Mod/UserMod.cs
+++ b/src/ContainerTooltips/Mod/UserMod.cs
@@ -152,10 +152,10 @@ public sealed class UserMod : UserMod2
 
     private static string GetLocStringText(LocString value)
     {
-        var englishText = value.ToString();
+        var englishText = value.text ?? string.Empty;
 
         if (string.IsNullOrEmpty(englishText))
-            englishText = value.text ?? string.Empty;
+            englishText = value.ToString();
 
         return englishText;
     }


### PR DESCRIPTION
## Summary
- ensure ContainerTooltips registers default strings using the LocString.text backing field before falling back to ToString()
- document the LocString precedence change and note the outstanding rebuild/in-game verification work

## Testing
- not run (dotnet tooling is unavailable in this container)


------
https://chatgpt.com/codex/tasks/task_e_68e44da89b1883298077adae070e6f8d