### PR TITLE
Fix BetterInfoCards overlay tint bleed

### DIFF
--- a/ERRORS.md
+++ b/ERRORS.md
@@ -41,3 +41,9 @@
 - **Issue:** The FixedMod-specific `Directory.Build.props` and `.targets` imported `../src/...`, which resolved to the same directory and caused MSBuild to report a circular dependency when the solution loaded in Visual Studio.
 - **Resolution:** Updated the relative paths to `../../src/...` so the FixedMod projects now import the shared root build settings without recursion.
 - **Status:** Fixed
+
+## 2025-11-29 - BetterInfoCards overlay tint bleed
+- **Module:** BetterInfoCards hover card styling
+- **Issue:** Overriding the `shadowBarWidget` tint at construction time recolored every `HoverTextDrawer` consumer, so world overlays adopted the info card background color.
+- **Resolution:** Stop mutating the skin prefab and instead recolor the instantiated shadow bar for each BetterInfoCards hover card during replay.
+- **Status:** Fixed

--- a/NOTES.md
+++ b/NOTES.md
@@ -315,3 +315,8 @@
 ## 2025-12-05 - ContainerTooltips LocString text precedence
 - Adjusted `UserMod.GetLocStringText` to prefer the embedded `LocString.text` over `ToString()` so the default "Contents"/"None" registration values win when translations are missing.
 - `dotnet` remains unavailable in this environment, so `dotnet build src/oniMods.sln` could not be executed. In-game verification of the updated storage tooltip header should be performed locally.
+
+## 2025-11-29 - BetterInfoCards overlay tint bleed
+- Reproduced the report by reviewing the Harmony patches: the shadow bar prefab tint was applied during every `HoverTextDrawer` construction, so overlays inherited the BetterInfoCards background color.
+- Updated the replay flow to recolor only the instantiated shadow bars captured by `ExportWidgets`, preventing other systems from inheriting the tint.
+- Could not validate the visual fix in this container because the ONI runtime is unavailable; follow up in-game once the mod is rebuilt locally per `src/README.md`.

--- a/src/BetterInfoCards/Process/ProcessHoverInfo.cs
+++ b/src/BetterInfoCards/Process/ProcessHoverInfo.cs
@@ -2,6 +2,7 @@ using BetterInfoCards.Export;
 using BetterInfoCards.Process;
 using HarmonyLib;
 using UnityEngine;
+using UnityEngine.UI;
 
 namespace BetterInfoCards
 {
@@ -32,6 +33,15 @@ namespace BetterInfoCards
             var widgets = ExportWidgets.ConsumeWidgets();
             if (widgets.Count > 0)
             {
+                foreach (var cardWidgets in widgets)
+                {
+                    var shadowBarGraphic = cardWidgets?.shadowBar?.Rect != null
+                        ? cardWidgets.shadowBar.Rect.GetComponent<Graphic>()
+                        : null;
+
+                    CardTweaker.ApplyShadowBarColor(shadowBarGraphic);
+                }
+
                 var grid = new Grid(widgets, widgets[0].YMax);
                 grid.MoveAndResizeInfoCards();
             }

--- a/src/BetterInfoCards/Tweaks/CardTweaker.cs
+++ b/src/BetterInfoCards/Tweaks/CardTweaker.cs
@@ -24,8 +24,6 @@ namespace BetterInfoCards
             {
                 if (ShouldTweak)
                     skin.shadowBarBorder = border;
-
-                ApplyShadowBarColor(skin.shadowBarWidget);
             }
         }
 


### PR DESCRIPTION
## Summary
- stop recoloring the HoverTextDrawer skin prefab so overlay palettes stay unchanged
- tint BetterInfoCards shadow bars after replaying the captured widgets to keep the custom background on cards only
- document the overlay tint regression in ERRORS.md and NOTES.md for future tracking

## Testing
- not run (container lacks the ONI/.NET toolchain)


------
https://chatgpt.com/codex/tasks/task_e_68e4533bb4188329a42a9d35588ccf91