### PR TITLE
Add UnityEngine imports to DevLoader logging patches

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -284,6 +284,10 @@
 - Updated `MassDisplayMode` to use a uniquely named alias for `global::GameUtil` so ContainerTooltips no longer collides with other `GameUtil` aliases when loaded alongside mods.
 - The workspace still lacks the ONI-managed assemblies and `.NET` runtime, preventing a rebuild; maintainers should run `dotnet build src/oniMods.sln` locally to confirm the enum resolves without namespace conflicts.
 
+## 2025-12-07 - DevLoader logging namespace imports
+- Added missing `using UnityEngine;` directives to the DevLoader patches so `Debug.*` resolves against the Unity logging API again.
+- Could not rebuild `DevLoader` in-container because the .NET host is unavailable (`command not found: dotnet`); please run `dotnet build src/DevLoader/DevLoader.csproj` locally to confirm the project compiles without missing-type errors.
+
 ## 2025-11-29 - ContainerTooltips Storage.OnSpawn patch accessibility
 - Replaced the `nameof(Storage.OnSpawn)` Harmony target with a literal string to avoid accessibility errors when the nested `OnSpawn` reference is unavailable at compile time.
 - Attempted to rebuild via `dotnet build src/ContainerTooltips/ContainerTooltips.csproj`, but the container still lacks the `.NET` host (`dotnet` command not found); maintainers should rebuild locally to confirm the accessibility warning no longer occurs.

--- a/src/DevLoader/DevLoader/GameLogPatch.cs
+++ b/src/DevLoader/DevLoader/GameLogPatch.cs
@@ -1,4 +1,5 @@
 using HarmonyLib;
+using UnityEngine;
 
 namespace DevLoader;
 

--- a/src/DevLoader/DevLoader/LoaderFilterPatch.cs
+++ b/src/DevLoader/DevLoader/LoaderFilterPatch.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Reflection;
 using HarmonyLib;
+using UnityEngine;
 
 namespace DevLoader;
 

--- a/src/DevLoader/DevLoader/MainMenuLogPatch.cs
+++ b/src/DevLoader/DevLoader/MainMenuLogPatch.cs
@@ -1,4 +1,5 @@
 using HarmonyLib;
+using UnityEngine;
 
 namespace DevLoader;
 

--- a/src/DevLoader/DevLoader/ManagementMenuLogPatch.cs
+++ b/src/DevLoader/DevLoader/ManagementMenuLogPatch.cs
@@ -1,4 +1,5 @@
 using HarmonyLib;
+using UnityEngine;
 
 namespace DevLoader;
 

--- a/src/DevLoader/DevLoader/ModLoadFilterPatch.cs
+++ b/src/DevLoader/DevLoader/ModLoadFilterPatch.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Reflection;
 using HarmonyLib;
+using UnityEngine;
 
 namespace DevLoader;
 

--- a/src/DevLoader/DevLoader/Runtime.cs
+++ b/src/DevLoader/DevLoader/Runtime.cs
@@ -1,4 +1,5 @@
 using System;
+using UnityEngine;
 
 namespace DevLoader;
 


### PR DESCRIPTION
## Summary
- add UnityEngine namespace imports to DevLoader Harmony patches so Debug resolves
- document the missing toolchain rebuild follow-up in NOTES.md for maintainers

## Testing
- dotnet build src/DevLoader/DevLoader.csproj *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68e57589a9788329810e5b8a9a2a9db2