### PR TITLE
Document manual DevLoader badge asset upload

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -328,3 +328,14 @@
 ## 2025-12-06 - DevLoader metadata alignment
 - Updated `DevLoader.csproj` to rely on the shared build props for references and assembly info so the project inherits the publicized ONI assemblies automatically.
 - Attempted to run `dotnet build src/DevLoader/DevLoader.csproj`, but the container still lacks the `.NET` host (`dotnet` command not found); maintainers should rebuild locally to confirm the shared references resolve.
+
+## 2025-12-07 - DevLoader badge artwork distribution
+- Added the missing badge sprites under `src/DevLoader/Images/` so the runtime loader can resolve `dev_on.png`, `dev_off.png`, and their mini variants without warning spam.
+- Updated `DevLoader.csproj` to mark each PNG as `Content` with `CopyToOutputDirectory=PreserveNewest`, ensuring they ship alongside the DLL during builds.
+- Unable to verify with `dotnet build src/DevLoader/DevLoader.csproj` because the container still reports `command not found: dotnet`; please rebuild locally to confirm the assets copy into the output folder.
+
+## 2025-12-08 - DevLoader badge artwork placeholder follow-up
+- Removed the placeholder sprite commit from source control; the container cannot host the final badge PNGs without breaking licensing, so the `Images/` directory is now empty apart from documentation.
+- Updated `DevLoader.csproj` to copy any `.png` under `src/DevLoader/Images/` when present, keeping the build ready for locally supplied art assets.
+- Added `src/DevLoader/Images/README.md` with instructions to drop `dev_on.png`, `dev_off.png`, `mini_dev_on.png`, and `mini_dev_off.png` into the folder before building.
+- Still blocked from running `dotnet build src/DevLoader/DevLoader.csproj` in this container (`command not found: dotnet`); rerun the build locally after restoring the four PNGs.

--- a/src/DevLoader/DevLoader.csproj
+++ b/src/DevLoader/DevLoader.csproj
@@ -10,4 +10,9 @@
   <PropertyGroup>
     <UsesAzeLib>false</UsesAzeLib>
   </PropertyGroup>
+  <ItemGroup Condition="Exists('Images')">
+    <Content Include="Images\*.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/src/DevLoader/Images/README.md
+++ b/src/DevLoader/Images/README.md
@@ -1,0 +1,10 @@
+# DevLoader badge artwork placeholder
+
+The DevLoader badge expects four PNGs that ship alongside the DLL:
+
+- `dev_on.png`
+- `dev_off.png`
+- `mini_dev_on.png`
+- `mini_dev_off.png`
+
+Drop the finalized assets into this folder before building; the project file copies any `.png` in this directory to the output.


### PR DESCRIPTION
## Summary
- remove the DevLoader badge PNGs from source control and replace them with documentation pointing to the required filenames
- update DevLoader.csproj to copy any PNGs dropped into the Images directory so locally supplied artwork still ships with the DLL
- record the manual asset upload requirement and ongoing build limitation in NOTES.md for maintainers

## Testing
- ❌ `dotnet build src/DevLoader/DevLoader.csproj` *(fails: `dotnet` command is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e576a2ccb883298351f49a9ebe3eb6