### PR TITLE
Fix DevLoader CS1525 decompiler artifacts

### DIFF
--- a/ERRORS.md
+++ b/ERRORS.md
@@ -47,3 +47,9 @@
 - **Issue:** Overriding the `shadowBarWidget` tint at construction time recolored every `HoverTextDrawer` consumer, so world overlays adopted the info card background color.
 - **Resolution:** Stop mutating the skin prefab and instead recolor the instantiated shadow bar for each BetterInfoCards hover card during replay.
 - **Status:** Fixed
+
+## 2025-12-09 - DevLoader decompiler artifacts (CS1525)
+- **Module:** DevLoader bootstrap and badge UI wiring
+- **Issue:** The DevLoader project would not compile because the decompiled sources still contained ILSpy ref-cast helpers (e.g., `((Scene)(ref scene)).name`, `((Rect)(ref rect)).width`) that generate CS1525 syntax errors under the Unity/.NET compiler.
+- **Resolution:** Replaced the ref-cast helper calls with direct property access, reintroduced idiomatic `Vector2` construction for anchor settings, and cached the sprite rect once when configuring the badge layout.
+- **Status:** Fixed

--- a/NOTES.md
+++ b/NOTES.md
@@ -343,3 +343,8 @@
 - Updated `DevLoader.csproj` to copy any `.png` under `src/DevLoader/Images/` when present, keeping the build ready for locally supplied art assets.
 - Added `src/DevLoader/Images/README.md` with instructions to drop `dev_on.png`, `dev_off.png`, `mini_dev_on.png`, and `mini_dev_off.png` into the folder before building.
 - Still blocked from running `dotnet build src/DevLoader/DevLoader.csproj` in this container (`command not found: dotnet`); rerun the build locally after restoring the four PNGs.
+
+## 2025-12-09 - DevLoader CS1525 cleanup
+- Replaced the lingering ILSpy ref-cast helpers in `DevMiniBootstrap`, `CenterMini`, and `UI` with idiomatic property access and `Vector2` construction so Unity's compiler stops reporting CS1525 syntax errors.
+- Cached the badge sprite rect once when configuring the layout element to avoid repeated struct copies while setting width and height.
+- Attempted to rebuild with `dotnet build src/DevLoader/DevLoader.csproj`, but the container still reports `command not found: dotnet`; maintainers must re-run the build on a workstation with the ONI toolchain to confirm the cleanup compiles.【1200ed†L1-L2】

--- a/src/DevLoader/DevLoader/CenterMini.cs
+++ b/src/DevLoader/DevLoader/CenterMini.cs
@@ -116,16 +116,15 @@ public static class CenterMini
 			Runtime.Toggled += OnToggled;
 			UpdateIcon();
 		}
-		RectTransform obj3 = val;
-		RectTransform obj4 = val;
-		RectTransform obj5 = val;
-		Vector2 val5 = default(Vector2);
-		((Vector2)(ref val5))._002Ector(1f, 1f);
-		obj5.pivot = val5;
-		Vector2 anchorMin = (obj4.anchorMax = val5);
-		obj3.anchorMin = anchorMin;
-		val.anchoredPosition = new Vector2(-1100f, -18f);
-	}
+                if (!((Object)(object)val == (Object)null))
+                {
+                        Vector2 anchor = new Vector2(1f, 1f);
+                        val.pivot = anchor;
+                        val.anchorMin = anchor;
+                        val.anchorMax = anchor;
+                        val.anchoredPosition = new Vector2(-1100f, -18f);
+                }
+        }
 
 	private static void OnToggled(bool enabled)
 	{

--- a/src/DevLoader/DevLoader/DevMiniBootstrap.cs
+++ b/src/DevLoader/DevLoader/DevMiniBootstrap.cs
@@ -41,11 +41,11 @@ internal sealed class DevMiniBootstrap : MonoBehaviour
 		Debug.Log((object)"[DevLoader][MiniCenter] Bootstrap Destroy");
 	}
 
-	private void OnActiveSceneChanged(Scene oldS, Scene newS)
-	{
-		Debug.Log((object)("[DevLoader][MiniCenter] SceneChanged: " + ((Scene)(ref oldS)).name + " -> " + ((Scene)(ref newS)).name));
-		TryInstallNow();
-	}
+        private void OnActiveSceneChanged(Scene oldS, Scene newS)
+        {
+                Debug.Log((object)("[DevLoader][MiniCenter] SceneChanged: " + oldS.name + " -> " + newS.name));
+                TryInstallNow();
+        }
 
 	private IEnumerator InstallUntilFound()
 	{
@@ -101,8 +101,8 @@ internal sealed class DevMiniBootstrap : MonoBehaviour
 				}
 			}
 		}
-		Scene activeScene = SceneManager.GetActiveScene();
-		GameObject[] rootGameObjects = ((Scene)(ref activeScene)).GetRootGameObjects();
+                Scene activeScene = SceneManager.GetActiveScene();
+                GameObject[] rootGameObjects = activeScene.GetRootGameObjects();
 		GameObject[] array4 = rootGameObjects;
 		foreach (GameObject val2 in array4)
 		{

--- a/src/DevLoader/DevLoader/UI.cs
+++ b/src/DevLoader/DevLoader/UI.cs
@@ -95,14 +95,11 @@ public static class UI
 		}
 		((Graphic)_img).SetNativeSize();
 		LayoutElement val2 = val.AddComponent<LayoutElement>();
-		Rect rect = _img.sprite.rect;
-		val2.minWidth = ((Rect)(ref rect)).width;
-		rect = _img.sprite.rect;
-		val2.minHeight = ((Rect)(ref rect)).height;
-		rect = _img.sprite.rect;
-		val2.preferredWidth = ((Rect)(ref rect)).width;
-		rect = _img.sprite.rect;
-		val2.preferredHeight = ((Rect)(ref rect)).height;
+                Rect rect = _img.sprite.rect;
+                val2.minWidth = rect.width;
+                val2.minHeight = rect.height;
+                val2.preferredWidth = rect.width;
+                val2.preferredHeight = rect.height;
 		Button component = val.GetComponent<Button>();
 		((Selectable)component).transition = (Transition)0;
 		ButtonClickedEvent onClick = component.onClick;


### PR DESCRIPTION
## Summary
- replace ILSpy ref-cast helpers in DevMiniBootstrap, CenterMini, and UI with direct property access and idiomatic Vector2 usage
- cache the DevLoader badge sprite rect during layout setup to avoid repeated struct access and remove CS1525 parsing errors
- document the cleanup in ERRORS.md and NOTES.md per the maintainer playbook

## Testing
- `dotnet build src/DevLoader/DevLoader.csproj` *(fails: command not found: dotnet in hosted container)*

------
https://chatgpt.com/codex/tasks/task_e_68e584686be48329b5e05c9a71271776