### PR TITLE
Align DevLoader references with shared props

### DIFF
--- a/ERRORS.md
+++ b/ERRORS.md
@@ -53,3 +53,9 @@
 - **Issue:** The DevLoader project would not compile because the decompiled sources still contained ILSpy ref-cast helpers (e.g., `((Scene)(ref scene)).name`, `((Rect)(ref rect)).width`) that generate CS1525 syntax errors under the Unity/.NET compiler.
 - **Resolution:** Replaced the ref-cast helper calls with direct property access, reintroduced idiomatic `Vector2` construction for anchor settings, and cached the sprite rect once when configuring the badge layout.
 - **Status:** Fixed
+## 2025-12-10 - DevLoader reference configuration drift
+- **Module:** DevLoader project configuration
+- **Issue:** `DevLoader.csproj` hard-coded ONI assembly references, diverging from the shared `Directory.Build.props` and forcing contributors to maintain local filesystem paths.
+- **Resolution:** Removed the redundant `<Reference>` entries so DevLoader now inherits the managed assembly references from the shared build targets.
+- **Status:** Fixed
+

--- a/NOTES.md
+++ b/NOTES.md
@@ -348,3 +348,7 @@
 - Replaced the lingering ILSpy ref-cast helpers in `DevMiniBootstrap`, `CenterMini`, and `UI` with idiomatic property access and `Vector2` construction so Unity's compiler stops reporting CS1525 syntax errors.
 - Cached the badge sprite rect once when configuring the layout element to avoid repeated struct copies while setting width and height.
 - Attempted to rebuild with `dotnet build src/DevLoader/DevLoader.csproj`, but the container still reports `command not found: dotnet`; maintainers must re-run the build on a workstation with the ONI toolchain to confirm the cleanup compiles.【1200ed†L1-L2】
+## 2025-12-10 - DevLoader shared reference cleanup
+- Removed the hard-coded `Assembly-CSharp`, `Assembly-CSharp-firstpass`, and `Unity.TextMeshPro` references from `DevLoader.csproj` so the project now relies on the shared `Directory.Build.props` targets for ONI assemblies.
+- Attempted to run `dotnet build src/oniMods.sln`, but the container still lacks the `.NET` host (`dotnet: command not found`); maintainers should rebuild locally to confirm DevLoader compiles against the shared targets.
+

--- a/src/DevLoader/DevLoader.csproj
+++ b/src/DevLoader/DevLoader.csproj
@@ -15,15 +15,4 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  <ItemGroup>
-    <Reference Include="Assembly-CSharp">
-      <HintPath>F:\SteamLibrary\steamapps\common\OxygenNotIncluded\OxygenNotIncluded_Data\Managed\Assembly-CSharp.dll</HintPath>
-    </Reference>
-    <Reference Include="Assembly-CSharp-firstpass">
-      <HintPath>F:\SteamLibrary\steamapps\common\OxygenNotIncluded\OxygenNotIncluded_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.TextMeshPro">
-      <HintPath>F:\SteamLibrary\steamapps\common\OxygenNotIncluded\OxygenNotIncluded_Data\Managed\Unity.TextMeshPro.dll</HintPath>
-    </Reference>
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- drop the hard-coded ONI assembly references from DevLoader.csproj so it inherits them from Directory.Build.props
- document the configuration cleanup in NOTES.md and mark the resolved drift in ERRORS.md

## Testing
- `dotnet build src/oniMods.sln` *(fails: command not found: dotnet in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e58557b98c8329a90febd57879b29e