### PR TITLE
Remove direct ONI assembly references from BetterInfoCards and ContainerTooltips

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -352,3 +352,8 @@
 - Removed the hard-coded `Assembly-CSharp`, `Assembly-CSharp-firstpass`, and `Unity.TextMeshPro` references from `DevLoader.csproj` so the project now relies on the shared `Directory.Build.props` targets for ONI assemblies.
 - Attempted to run `dotnet build src/oniMods.sln`, but the container still lacks the `.NET` host (`dotnet: command not found`); maintainers should rebuild locally to confirm DevLoader compiles against the shared targets.
 
+## 2025-12-11 - BetterInfoCards & ContainerTooltips reference cleanup
+- Dropped the hard-coded ONI assembly references from the BetterInfoCards and ContainerTooltips project files so they inherit the publicized `_public` DLLs via `Directory.Build.props`.
+- Kept the explicit `Microsoft.CSharp` reference for BetterInfoCards while relying on the shared props for the remaining dependencies to avoid duplicate hint paths.
+- Attempted to run `dotnet build src/oniMods.sln`, but the container still reports `command not found: dotnet`; maintainers should rebuild locally to confirm both projects resolve the shared `_public` assemblies.
+

--- a/src/BetterInfoCards/BetterInfoCards.csproj
+++ b/src/BetterInfoCards/BetterInfoCards.csproj
@@ -15,16 +15,7 @@
 	</ItemGroup>
 
         <ItemGroup>
-          <Reference Include="Assembly-CSharp">
-            <HintPath>F:\SteamLibrary\steamapps\common\OxygenNotIncluded\OxygenNotIncluded_Data\Managed\Assembly-CSharp.dll</HintPath>
-          </Reference>
-          <Reference Include="Assembly-CSharp-firstpass">
-            <HintPath>F:\SteamLibrary\steamapps\common\OxygenNotIncluded\OxygenNotIncluded_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
-          </Reference>
-          <Reference Include="Microsoft.CSharp" />
-          <Reference Include="Unity.TextMeshPro">
-            <HintPath>F:\SteamLibrary\steamapps\common\OxygenNotIncluded\OxygenNotIncluded_Data\Managed\Unity.TextMeshPro.dll</HintPath>
-          </Reference>
+                <Reference Include="Microsoft.CSharp" />
         </ItemGroup>
 
 </Project>

--- a/src/ContainerTooltips/ContainerTooltips.csproj
+++ b/src/ContainerTooltips/ContainerTooltips.csproj
@@ -12,15 +12,4 @@
   <PropertyGroup>
     <UsesAzeLib>false</UsesAzeLib>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Assembly-CSharp">
-      <HintPath>F:\SteamLibrary\steamapps\common\OxygenNotIncluded\OxygenNotIncluded_Data\Managed\Assembly-CSharp.dll</HintPath>
-    </Reference>
-    <Reference Include="Assembly-CSharp-firstpass">
-      <HintPath>F:\SteamLibrary\steamapps\common\OxygenNotIncluded\OxygenNotIncluded_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.TextMeshPro">
-      <HintPath>F:\SteamLibrary\steamapps\common\OxygenNotIncluded\OxygenNotIncluded_Data\Managed\Unity.TextMeshPro.dll</HintPath>
-    </Reference>
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- remove the hard-coded ONI assembly hint paths from the BetterInfoCards and ContainerTooltips projects so they rely on the shared `_public` DLL references
- keep the explicit `Microsoft.CSharp` reference that BetterInfoCards still requires and document the cleanup in `NOTES.md`

## Testing
- ❌ `dotnet build src/oniMods.sln` *(missing `dotnet` host in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5905254a8832984b8b1a6fb490ca5