### PR TITLE
Adjust default Steam install path

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -357,3 +357,7 @@
 - Kept the explicit `Microsoft.CSharp` reference for BetterInfoCards while relying on the shared props for the remaining dependencies to avoid duplicate hint paths.
 - Attempted to run `dotnet build src/oniMods.sln`, but the container still reports `command not found: dotnet`; maintainers should rebuild locally to confirm both projects resolve the shared `_public` assemblies.
 
+## 2025-12-12 - Directory.Build.props default path cleanup
+- Updated `Directory.Build.props.default` to default `SteamFolder` to the stock `C:\Program Files (x86)\Steam` install location and documented the `.user` override for custom setups.
+- Attempted to run `dotnet build src/oniMods.sln` to confirm a clean clone compiles without editing `.default`, but the container still lacks the `.NET` host (`dotnet: command not found`). Rebuild locally to verify.
+

--- a/src/Directory.Build.props.default
+++ b/src/Directory.Build.props.default
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
+  <!-- If your local Steam install lives elsewhere, copy this file to Directory.Build.props.user and customize it there. -->
   <PropertyGroup>
-    <SteamFolder>F:\SteamLibrary</SteamFolder>
+    <SteamFolder>C:\Program Files (x86)\Steam</SteamFolder>
     <GameFolder>$(SteamFolder)\steamapps\common\OxygenNotIncluded\OxygenNotIncluded_Data\Managed</GameFolder>
     <ModFolder>$(UserProfile)\Documents\Klei\OxygenNotIncluded\mods\dev</ModFolder>
   </PropertyGroup>


### PR DESCRIPTION
## Summary
- point the default `SteamFolder` in `Directory.Build.props.default` at the stock `C:\Program Files (x86)\Steam` install location
- document how to override the defaults via `Directory.Build.props.user`
- record the configuration update and the blocked build verification in `NOTES.md`

## Testing
- `dotnet build src/oniMods.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68e590efa458832993f1ef3d7472547e