### PR TITLE
Point AzeLib ONI references to GameFolder

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -357,6 +357,10 @@
 - Kept the explicit `Microsoft.CSharp` reference for BetterInfoCards while relying on the shared props for the remaining dependencies to avoid duplicate hint paths.
 - Attempted to run `dotnet build src/oniMods.sln`, but the container still reports `command not found: dotnet`; maintainers should rebuild locally to confirm both projects resolve the shared `_public` assemblies.
 
+## 2025-12-13 - AzeLib ONI reference hint cleanup
+- Repointed `AzeLib.csproj` to resolve `Assembly-CSharp` and `Assembly-CSharp-firstpass` via `$(GameFolder)` so local builds can rely on the shared `Directory.Build.props` overrides.
+- Attempted to run `dotnet build src/oniMods.sln`, but the container still lacks the `.NET` host (`command not found: dotnet`); rebuild locally once `GameFolder` is set through `.user` overrides.
+
 ## 2025-12-12 - Directory.Build.props default path cleanup
 - Updated `Directory.Build.props.default` to default `SteamFolder` to the stock `C:\Program Files (x86)\Steam` install location and documented the `.user` override for custom setups.
 - Attempted to run `dotnet build src/oniMods.sln` to confirm a clean clone compiles without editing `.default`, but the container still lacks the `.NET` host (`dotnet: command not found`). Rebuild locally to verify.

--- a/src/AzeLib/AzeLib.csproj
+++ b/src/AzeLib/AzeLib.csproj
@@ -8,12 +8,12 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <Reference Include="Assembly-CSharp">
-	    <HintPath>F:\SteamLibrary\steamapps\common\OxygenNotIncluded\OxygenNotIncluded_Data\Managed\Assembly-CSharp.dll</HintPath>
-	  </Reference>
-	  <Reference Include="Assembly-CSharp-firstpass">
-	    <HintPath>F:\SteamLibrary\steamapps\common\OxygenNotIncluded\OxygenNotIncluded_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
-	  </Reference>
+          <Reference Include="Assembly-CSharp">
+            <HintPath>$(GameFolder)\Assembly-CSharp.dll</HintPath>
+          </Reference>
+          <Reference Include="Assembly-CSharp-firstpass">
+            <HintPath>$(GameFolder)\Assembly-CSharp-firstpass.dll</HintPath>
+          </Reference>
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## Summary
- update AzeLib's Assembly-CSharp reference hint paths to use the shared `$(GameFolder)` MSBuild property
- document the reference cleanup and blocked build attempt in `NOTES.md`

## Testing
- `dotnet build src/oniMods.sln` *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e594c3a1408329a57fbc6265f7f29e