### PR TITLE
Point shared ONI references at publicized assemblies

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -365,3 +365,7 @@
 - Updated `Directory.Build.props.default` to default `SteamFolder` to the stock `C:\Program Files (x86)\Steam` install location and documented the `.user` override for custom setups.
 - Attempted to run `dotnet build src/oniMods.sln` to confirm a clean clone compiles without editing `.default`, but the container still lacks the `.NET` host (`dotnet: command not found`). Rebuild locally to verify.
 
+
+## 2025-10-07 - Directory.Build.props public assembly repointing
+- Updated `src/Directory.Build.props` so the shared ONI references resolve the `_public` DLLs generated under `src/lib`, preventing accidental fallbacks to the raw game assemblies.
+- Attempted to run `dotnet build src/oniMods.sln`, but the container still lacks the `.NET` host (`dotnet: command not found`). Please rebuild locally to confirm the solution consumes the publicized assemblies.

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -28,9 +28,9 @@
 					$(GameFolder)/Assembly-CSharp.dll;
 					$(GameFolder)/Assembly-CSharp-firstpass.dll;
                     $(GameFolder)/Unity.TextMeshPro.dll"/>
-    <Reference Include="Assembly-CSharp_public" HintPath="../lib/Assembly-CSharp.dll"  />
-    <Reference Include="Assembly-CSharp-firstpass_public" HintPath="../lib/Assembly-CSharp-firstpass.dll" />
-    <Reference Include="Unity.TextMeshPro_public" HintPath="../lib/Unity.TextMeshPro.dll" />
+    <Reference Include="Assembly-CSharp_public" HintPath="../lib/Assembly-CSharp_public.dll"  />
+    <Reference Include="Assembly-CSharp-firstpass_public" HintPath="../lib/Assembly-CSharp-firstpass_public.dll" />
+    <Reference Include="Unity.TextMeshPro_public" HintPath="../lib/Unity.TextMeshPro_public.dll" />
 
     <!--Meta References-->
     <PackageReference Include="ILRepack.Lib.MSBuild.Task" Version="*" />


### PR DESCRIPTION
## Summary
- update src/Directory.Build.props so the shared ONI references resolve the generated _public assemblies in src/lib
- document the reference change and the blocked rebuild in NOTES.md

## Testing
- `dotnet build src/oniMods.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e59560bb8c8329a877adf48559e6e4