### PR TITLE
Fix ContainerTooltips storage lifecycle visibility

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -366,6 +366,11 @@
 - Attempted to run `dotnet build src/oniMods.sln` to confirm a clean clone compiles without editing `.default`, but the container still lacks the `.NET` host (`dotnet: command not found`). Rebuild locally to verify.
 
 
+## 2025-12-14 - ContainerTooltips lifecycle visibility tweak
+- Exposed the `StorageContentsBehaviour` lifecycle hooks as `public override` so Unity can invoke them even when the component is instantiated from mod code rather than through prefab registration.
+- Attempted to rebuild with `dotnet build src/oniMods.sln /t:ContainerTooltips`, but the container still lacks the `.NET` host (`dotnet: command not found`). Please rerun the build locally to confirm the accessibility change compiles cleanly.
+
+
 ## 2025-10-07 - Directory.Build.props public assembly repointing
 - Updated `src/Directory.Build.props` so the shared ONI references resolve the `_public` DLLs generated under `src/lib`, preventing accidental fallbacks to the raw game assemblies.
 - Attempted to run `dotnet build src/oniMods.sln`, but the container still lacks the `.NET` host (`dotnet: command not found`). Please rebuild locally to confirm the solution consumes the publicized assemblies.

--- a/src/ContainerTooltips/Storage/StorageContentsBehaviour.cs
+++ b/src/ContainerTooltips/Storage/StorageContentsBehaviour.cs
@@ -14,7 +14,7 @@ public sealed class StorageContentsBehaviour : KMonoBehaviour
     private Storage? storage;
     private KSelectable? selectable;
 
-    protected override void OnPrefabInit()
+    public override void OnPrefabInit()
     {
         base.OnPrefabInit();
         storage = GetComponent<Storage>();
@@ -22,13 +22,13 @@ public sealed class StorageContentsBehaviour : KMonoBehaviour
         Subscribe((int)GameHashes.OnStorageChange, OnStorageChangedHandler);
     }
 
-    protected override void OnSpawn()
+    public override void OnSpawn()
     {
         base.OnSpawn();
         RefreshStatus();
     }
 
-    protected override void OnCleanUp()
+    public override void OnCleanUp()
     {
         ClearStatus();
         Unsubscribe((int)GameHashes.OnStorageChange, OnStorageChangedHandler);


### PR DESCRIPTION
## Summary
- expose `StorageContentsBehaviour` lifecycle overrides as `public` so Unity can invoke them when the component is spawned through mod code
- log the accessibility change and document the blocked build in `NOTES.md`

## Testing
- dotnet build src/oniMods.sln /t:ContainerTooltips *(fails: `dotnet` host is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5974e80688329ad6d0393984a7282