### PR TITLE
Fix UnityEngine.Object alias usage in DevLoader

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -58,6 +58,10 @@
 - Relaxed the widget matching so `InfoCardWidgets` recognises hover drawer clones by comparing prefab names (sans `"(Clone)"`) and verifying the component layout/rect dimensions.
 - Unable to rebuild or verify the mod in-game here because the container lacks the ONI managed assemblies and a .NET runtime; maintainers should rebuild via `dotnet build src/oniMods.sln` and confirm stacked hover cards wrap correctly.
 
+## 2025-10-14 - DevLoader UnityEngine.Object alias cleanup
+- Updated DevLoader's runtime UI helpers to alias `UnityEngine.Object` explicitly so null checks resolve against Unity's overloads instead of `System.Object`.
+- Attempted to verify by running `dotnet build src/oniMods.sln -t:DevLoader`, but the container still lacks a .NET host (`dotnet` command missing), so compilation must be performed on a workstation with the ONI toolchain installed.
+
 ## 2025-10-14 - BetterInfoCards .NET 4.7 compatibility cleanup
 - Replaced the C# 8 range expression in `StripCloneSuffix` with an explicit `Substring` call so the project compiles under the original .NET 4.7 target.
 - Attempted to rebuild via `dotnet build src/BetterInfoCards/BetterInfoCards.csproj`, but the container still lacks the .NET host (`dotnet` command is unavailable), so compilation must be verified on a workstation with the ONI assemblies and toolchain installed.

--- a/src/DevLoader/DevLoader/CenterMini.cs
+++ b/src/DevLoader/DevLoader/CenterMini.cs
@@ -4,6 +4,7 @@ using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.UI;
+using Object = UnityEngine.Object;
 
 namespace DevLoader;
 
@@ -52,10 +53,10 @@ public static class CenterMini
 		//IL_0259: Unknown result type (might be due to invalid IL or missing references)
 		//IL_025e: Unknown result type (might be due to invalid IL or missing references)
 		//IL_0264: Expected O, but got Unknown
-		Debug.Log((object)("[DevLoader][MiniCenter] Ensure ENTER parentHint=" + (((Object)(object)parentHint != (Object)null) ? ((Object)parentHint).name : "<null>")));
+		Debug.Log((object)("[DevLoader][MiniCenter] Ensure ENTER parentHint=" + (((Object)parentHint != null) ? ((Object)parentHint).name : "<null>")));
 		GameObject obj = GameObject.Find("DevCenterMiniButton");
 		RectTransform val = ((obj != null) ? obj.GetComponent<RectTransform>() : null);
-		if ((Object)(object)val != (Object)null)
+		if ((Object)val != null)
 		{
 			Debug.Log((object)"[DevLoader][MiniCenter] Ya existe el botón mini, reubicando...");
 		}
@@ -63,14 +64,14 @@ public static class CenterMini
 		{
 			_onMini = TryLoadMini("mini_dev_on.png", "mini_dev_on");
 			_offMini = TryLoadMini("mini_dev_off.png", "mini_dev_off");
-			Debug.Log((object)("[DevLoader][MiniCenter] Sprites: on=" + (Object.op_Implicit((Object)(object)_onMini) ? ((Object)_onMini).name : "<null>") + " off=" + (Object.op_Implicit((Object)(object)_offMini) ? ((Object)_offMini).name : "<null>")));
-			Transform val2 = (((Object)(object)parentHint != (Object)null) ? parentHint.root : null);
-			if ((Object)(object)val2 == (Object)null && (Object)(object)parentHint != (Object)null)
+			Debug.Log((object)("[DevLoader][MiniCenter] Sprites: on=" + (Object.op_Implicit((Object)_onMini) ? ((Object)_onMini).name : "<null>") + " off=" + (Object.op_Implicit((Object)_offMini) ? ((Object)_offMini).name : "<null>")));
+			Transform val2 = (((Object)parentHint != null) ? parentHint.root : null);
+			if ((Object)val2 == null && (Object)parentHint != null)
 			{
 				val2 = parentHint;
 			}
-			Debug.Log((object)("[DevLoader][MiniCenter] Parent picked: " + (((Object)(object)val2 != (Object)null) ? ((Object)val2).name : "<null>")));
-			if ((Object)(object)val2 == (Object)null)
+			Debug.Log((object)("[DevLoader][MiniCenter] Parent picked: " + (((Object)val2 != null) ? ((Object)val2).name : "<null>")));
+			if ((Object)val2 == null)
 			{
 				Debug.LogWarning((object)"[DevLoader][MiniCenter] parent NULL, abort");
 				return;
@@ -87,7 +88,7 @@ public static class CenterMini
 			_img.preserveAspect = true;
 			((Graphic)_img).color = Color.white;
 			_img.sprite = (Config.Enabled ? (_onMini ?? _offMini) : (_offMini ?? _onMini));
-			Debug.Log((object)("[DevLoader][MiniCenter] Image sprite set -> " + (Object.op_Implicit((Object)(object)_img.sprite) ? ((Object)_img.sprite).name : "<null>")));
+			Debug.Log((object)("[DevLoader][MiniCenter] Image sprite set -> " + (Object.op_Implicit((Object)_img.sprite) ? ((Object)_img.sprite).name : "<null>")));
 			Button component = val3.GetComponent<Button>();
 			((Selectable)component).transition = (Transition)0;
 			((UnityEventBase)component.onClick).RemoveAllListeners();
@@ -116,7 +117,7 @@ public static class CenterMini
 			Runtime.Toggled += OnToggled;
 			UpdateIcon();
 		}
-                if (!((Object)(object)val == (Object)null))
+                if ((Object)val != null)
                 {
                         Vector2 anchor = new Vector2(1f, 1f);
                         val.pivot = anchor;
@@ -134,14 +135,14 @@ public static class CenterMini
 
 	private static void UpdateIcon()
 	{
-		if ((Object)(object)_img == (Object)null)
+		if ((Object)_img == null)
 		{
 			Debug.LogWarning((object)"[DevLoader][MiniCenter] UpdateIcon with _img NULL");
 			return;
 		}
 		Sprite val = (Config.Enabled ? (_onMini ?? _offMini) : (_offMini ?? _onMini));
 		_img.sprite = val;
-		Debug.Log((object)("[DevLoader][MiniCenter] UpdateIcon -> " + (Config.Enabled ? "ON" : "OFF") + " sprite=" + (Object.op_Implicit((Object)(object)val) ? ((Object)val).name : "<null>")));
+		Debug.Log((object)("[DevLoader][MiniCenter] UpdateIcon -> " + (Config.Enabled ? "ON" : "OFF") + " sprite=" + (Object.op_Implicit((Object)val) ? ((Object)val).name : "<null>")));
 	}
 
 	private static Sprite TryLoadMini(string file, string atlasKey)
@@ -179,7 +180,7 @@ public static class CenterMini
 		try
 		{
 			Sprite sprite = Assets.GetSprite(HashedString.op_Implicit(atlasKey));
-			Debug.Log((object)("[DevLoader][MiniCenter] Atlas  + atlasKey +  -> " + (Object.op_Implicit((Object)(object)sprite) ? ((Object)sprite).name : "<null>")));
+			Debug.Log((object)("[DevLoader][MiniCenter] Atlas  + atlasKey +  -> " + (Object.op_Implicit((Object)sprite) ? ((Object)sprite).name : "<null>")));
 			return sprite;
 		}
 		catch (Exception ex2)

--- a/src/DevLoader/DevLoader/DevMiniBootstrap.cs
+++ b/src/DevLoader/DevLoader/DevMiniBootstrap.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using UnityEngine;
 using UnityEngine.SceneManagement;
+using Object = UnityEngine.Object;
 
 namespace DevLoader;
 
@@ -13,7 +14,7 @@ internal sealed class DevMiniBootstrap : MonoBehaviour
 
 	private void Awake()
 	{
-		Object.DontDestroyOnLoad((Object)(object)((Component)this).gameObject);
+		Object.DontDestroyOnLoad((Object)((Component)this).gameObject);
 		((Object)this).name = "DevMiniBootstrap";
 		Debug.Log((object)"[DevLoader][MiniCenter] Bootstrap Awake");
 	}
@@ -57,7 +58,7 @@ internal sealed class DevMiniBootstrap : MonoBehaviour
 				yield return (object)new WaitForSecondsRealtime(1f);
 			}
 		}
-		Object.Destroy((Object)(object)((Component)this).gameObject);
+		Object.Destroy((Object)((Component)this).gameObject);
 	}
 
 	private void TryInstallNow()
@@ -69,8 +70,8 @@ internal sealed class DevMiniBootstrap : MonoBehaviour
 		try
 		{
 			Transform val = FindIngameParent();
-			Debug.Log((object)("[DevLoader][MiniCenter] TryInstallNow parent=" + (Object.op_Implicit((Object)(object)val) ? ((Object)val).name : "<null>")));
-			if ((Object)(object)val != (Object)null)
+			Debug.Log((object)("[DevLoader][MiniCenter] TryInstallNow parent=" + (Object.op_Implicit((Object)val) ? ((Object)val).name : "<null>")));
+			if ((Object)val != null)
 			{
 				CenterMini.Ensure(val);
 				installed = true;
@@ -107,7 +108,7 @@ internal sealed class DevMiniBootstrap : MonoBehaviour
 		foreach (GameObject val2 in array4)
 		{
 			Transform transform = val2.transform;
-			if ((Object)(object)transform != (Object)null && ((Object)transform).name.IndexOf("Canvas", StringComparison.OrdinalIgnoreCase) >= 0)
+			if ((Object)transform != null && ((Object)transform).name.IndexOf("Canvas", StringComparison.OrdinalIgnoreCase) >= 0)
 			{
 				return transform;
 			}

--- a/src/DevLoader/DevLoader/Hotkeys.cs
+++ b/src/DevLoader/DevLoader/Hotkeys.cs
@@ -1,5 +1,6 @@
 using System;
 using UnityEngine;
+using Object = UnityEngine.Object;
 
 namespace DevLoader;
 
@@ -17,7 +18,7 @@ public class Hotkeys : MonoBehaviour
 		{
 			return;
 		}
-		if ((Object)(object)Game.Instance != (Object)null && (Object)(object)PauseScreen.Instance != (Object)null)
+                if ((Object)Game.Instance != null && (Object)PauseScreen.Instance != null)
 		{
 			Debug.Log((object)"[DevLoader] Ctrl+1 → Saliendo al menú sin guardar");
 			LoadingOverlay.Load((Action)delegate

--- a/src/DevLoader/DevLoader/LiveLoader.cs
+++ b/src/DevLoader/DevLoader/LiveLoader.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using HarmonyLib;
 using KMod;
 using UnityEngine;
+using Object = UnityEngine.Object;
 
 namespace DevLoader;
 
@@ -176,10 +177,10 @@ public static class LiveLoader
 			Marker[] array2 = array;
 			foreach (Marker marker in array2)
 			{
-				if ((Object)(object)marker != (Object)null && (Object)(object)((Component)marker).gameObject != (Object)null)
+				if ((Object)marker != null && (Object)((Component)marker).gameObject != null)
 				{
 					num4++;
-					Object.Destroy((Object)(object)((Component)marker).gameObject);
+					Object.Destroy((Object)((Component)marker).gameObject);
 				}
 			}
 			Resources.UnloadUnusedAssets();

--- a/src/DevLoader/DevLoader/MainMenuPatch.cs
+++ b/src/DevLoader/DevLoader/MainMenuPatch.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using HarmonyLib;
 using UnityEngine;
 using UnityEngine.UI;
+using Object = UnityEngine.Object;
 
 namespace DevLoader;
 
@@ -22,18 +23,18 @@ public static class MainMenuPatch
 		{
 			KButton[] componentsInChildren2 = ((Component)val2).GetComponentsInChildren<KButton>(true);
 			RectTransform component = ((Component)val2).GetComponent<RectTransform>();
-			if (componentsInChildren2 != null && componentsInChildren2.Length >= 5 && (Object)(object)component != (Object)null && component.anchorMin.x <= 0.05f && component.anchorMax.x <= 0.4f)
+                        if (componentsInChildren2 != null && componentsInChildren2.Length >= 5 && (Object)component != null && component.anchorMin.x <= 0.05f && component.anchorMax.x <= 0.4f)
 			{
 				val = ((Component)val2).transform;
 				break;
 			}
 		}
-		if ((Object)(object)val == (Object)null)
+                if ((Object)val == null)
 		{
 			VerticalLayoutGroup obj = componentsInChildren.FirstOrDefault((VerticalLayoutGroup vg) => ((Component)vg).GetComponentsInChildren<KButton>(true).Length >= 5);
 			val = ((obj != null) ? ((Component)obj).transform : null);
 		}
-		if ((Object)(object)val == (Object)null)
+                if ((Object)val == null)
 		{
 			return;
 		}
@@ -41,7 +42,7 @@ public static class MainMenuPatch
 		val.GetChild(val.childCount - 1).SetAsLastSibling();
 		try
 		{
-			if ((Object)(object)GameObject.Find("DevMiniBootstrap") == (Object)null)
+                        if ((Object)GameObject.Find("DevMiniBootstrap") == null)
 			{
 				GameObject val3 = new GameObject("DevMiniBootstrap");
 				val3.AddComponent<DevMiniBootstrap>();

--- a/src/DevLoader/DevLoader/Mark.cs
+++ b/src/DevLoader/DevLoader/Mark.cs
@@ -1,14 +1,15 @@
 using UnityEngine;
+using Object = UnityEngine.Object;
 
 namespace DevLoader;
 
 public static class Mark
 {
-	public static void Add(GameObject go)
-	{
-		if (!((Object)(object)go == (Object)null) && (Object)(object)go.GetComponent<Marker>() == (Object)null)
-		{
-			go.AddComponent<Marker>();
-		}
-	}
+        public static void Add(GameObject go)
+        {
+                if ((Object)go != null && (Object)go.GetComponent<Marker>() == null)
+                {
+                        go.AddComponent<Marker>();
+                }
+        }
 }

--- a/src/DevLoader/DevLoader/Mod.cs
+++ b/src/DevLoader/DevLoader/Mod.cs
@@ -2,6 +2,7 @@ using System;
 using HarmonyLib;
 using KMod;
 using UnityEngine;
+using Object = UnityEngine.Object;
 
 namespace DevLoader;
 
@@ -32,10 +33,10 @@ public class Mod : UserMod2
 		}
 		try
 		{
-			if ((Object)(object)s_hotkeysGO == (Object)null)
+                        if ((Object)s_hotkeysGO == null)
 			{
 				s_hotkeysGO = new GameObject("DevLoaderHotkeys");
-				Object.DontDestroyOnLoad((Object)(object)s_hotkeysGO);
+                                Object.DontDestroyOnLoad((Object)s_hotkeysGO);
 				s_hotkeysGO.AddComponent<Hotkeys>();
 				Debug.Log((object)"[DevLoader] Hotkeys listo (Ctrl+F1 / Ctrl+1).");
 			}

--- a/src/DevLoader/DevLoader/UI.cs
+++ b/src/DevLoader/DevLoader/UI.cs
@@ -4,6 +4,7 @@ using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.UI;
+using Object = UnityEngine.Object;
 
 namespace DevLoader;
 
@@ -31,14 +32,14 @@ public static class UI
 
 	private static bool _badgeForcedOnce;
 
-	public static void EnsureSprites()
-	{
-		if (!((Object)(object)_on != (Object)null) || !((Object)(object)_off != (Object)null))
-		{
-			_on = LoadSprite("dev_on.png");
-			_off = LoadSprite("dev_off.png");
-		}
-	}
+        public static void EnsureSprites()
+        {
+                if ((Object)_on == null || (Object)_off == null)
+                {
+                        _on = LoadSprite("dev_on.png");
+                        _off = LoadSprite("dev_off.png");
+                }
+        }
 
 	internal static Sprite LoadSprite(string file)
 	{
@@ -118,12 +119,12 @@ public static class UI
 		Runtime.Toggled += UpdateBadge;
 	}
 
-	public static void UpdateBadge(bool enabled)
-	{
-		if (!((Object)(object)_img == (Object)null))
-		{
-			_img.sprite = (enabled ? _on : _off);
-			((Graphic)_img).SetNativeSize();
-		}
-	}
+        public static void UpdateBadge(bool enabled)
+        {
+                if ((Object)_img != null)
+                {
+                        _img.sprite = (enabled ? _on : _off);
+                        ((Graphic)_img).SetNativeSize();
+                }
+        }
 }


### PR DESCRIPTION
## Summary
- alias `UnityEngine.Object` in DevLoader runtime helpers to remove ambiguous `Object` references
- simplify Unity null comparisons and casts in UI, hotkeys, live loader, and mini badge support code
- log the missing `.NET` host in `NOTES.md` after the failed DevLoader build attempt

## Testing
- `dotnet build src/oniMods.sln -t:DevLoader` *(fails: `dotnet` command is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e598e59ef08329a05dfc2da2bebce5