### PR TITLE
Fix DevLoader Directory namespace clashes

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -379,6 +379,11 @@
 - Attempted to rebuild with `dotnet build src/oniMods.sln /t:ContainerTooltips`, but the container still lacks the `.NET` host (`dotnet: command not found`). Please rerun the build locally to confirm the accessibility change compiles cleanly.
 
 
+## 2025-12-15 - DevLoader directory namespace cleanup
+- Qualified every `Directory.*` call inside `LiveLoader` with `System.IO.` so the compiler no longer resolves the name against Unity's `UnityEngine.Directory` helper when both assemblies are loaded.
+- Wanted to validate the fix with `dotnet build src/DevLoader/DevLoader.csproj`, but the container still reports `command not found: dotnet`; please rebuild locally to confirm the namespace collision is resolved.
+
+
 ## 2025-10-07 - Directory.Build.props public assembly repointing
 - Updated `src/Directory.Build.props` so the shared ONI references resolve the `_public` DLLs generated under `src/lib`, preventing accidental fallbacks to the raw game assemblies.
 - Attempted to run `dotnet build src/oniMods.sln`, but the container still lacks the `.NET` host (`dotnet: command not found`). Please rebuild locally to confirm the solution consumes the publicized assemblies.

--- a/src/DevLoader/DevLoader/LiveLoader.cs
+++ b/src/DevLoader/DevLoader/LiveLoader.cs
@@ -52,9 +52,9 @@ public static class LiveLoader
 			int num2 = 0;
 			int num3 = 0;
 			int num4 = 0;
-			foreach (string item in list)
-			{
-				string[] files = Directory.GetFiles(item, "*.dll", SearchOption.AllDirectories);
+                        foreach (string item in list)
+                        {
+                                string[] files = System.IO.Directory.GetFiles(item, "*.dll", SearchOption.AllDirectories);
 				Debug.Log((object)$"[DevLoader] Buscando DLLs en: {item} -> {files.Length} archivos");
 				string[] array = files;
 				foreach (string text in array)
@@ -299,7 +299,7 @@ public static class LiveLoader
 			string fullPath = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
 			string parent = Path.Combine(fullPath, "mods");
 			string text = FindSubdirCaseInsensitive(parent, "dev");
-			if (Directory.Exists(text))
+                        if (System.IO.Directory.Exists(text))
 			{
 				list.Add(text);
 			}
@@ -312,7 +312,7 @@ public static class LiveLoader
 			string folderPath = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
 			string parent2 = Path.Combine(folderPath, "Klei", "OxygenNotIncluded", "mods");
 			string text2 = FindSubdirCaseInsensitive(parent2, "dev");
-			if (Directory.Exists(text2))
+                        if (System.IO.Directory.Exists(text2))
 			{
 				list.Add(text2);
 			}
@@ -323,10 +323,10 @@ public static class LiveLoader
 		try
 		{
 			string persistentDataPath = Application.persistentDataPath;
-			string path = Directory.GetParent(persistentDataPath)?.FullName ?? persistentDataPath;
+                        string path = System.IO.Directory.GetParent(persistentDataPath)?.FullName ?? persistentDataPath;
 			string parent3 = Path.Combine(path, "mods");
 			string text3 = FindSubdirCaseInsensitive(parent3, "dev");
-			if (Directory.Exists(text3))
+                        if (System.IO.Directory.Exists(text3))
 			{
 				list.Add(text3);
 			}
@@ -341,11 +341,11 @@ public static class LiveLoader
 	{
 		try
 		{
-			if (string.IsNullOrEmpty(parent) || !Directory.Exists(parent))
+                        if (string.IsNullOrEmpty(parent) || !System.IO.Directory.Exists(parent))
 			{
 				return "";
 			}
-			string[] directories = Directory.GetDirectories(parent);
+                        string[] directories = System.IO.Directory.GetDirectories(parent);
 			string[] array = directories;
 			foreach (string text in array)
 			{


### PR DESCRIPTION
## Summary
- prefix all Directory calls in DevLoader's LiveLoader with System.IO to avoid namespace collisions during compilation
- record the namespace fix and the .NET tooling limitation in NOTES.md for maintainers

## Testing
- `dotnet build src/DevLoader/DevLoader.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68e59aa6fd808329852359327a8fd0a5