### PR TITLE
Fix CenterMini hashed string conversion

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -384,6 +384,11 @@
 - Wanted to validate the fix with `dotnet build src/DevLoader/DevLoader.csproj`, but the container still reports `command not found: dotnet`; please rebuild locally to confirm the namespace collision is resolved.
 
 
+## 2025-12-16 - DevLoader CenterMini hashed string conversion
+- Replaced the implicit `HashedString` conversion in `CenterMini` with an explicit constructor call to avoid relying on the removed operator.
+- Attempted to rebuild with `dotnet build src/DevLoader/DevLoader.csproj`, but the container still lacks the `.NET` host (`command not found: dotnet`); rerun the build locally to confirm the change compiles without the implicit-operator error.
+
+
 ## 2025-10-07 - Directory.Build.props public assembly repointing
 - Updated `src/Directory.Build.props` so the shared ONI references resolve the `_public` DLLs generated under `src/lib`, preventing accidental fallbacks to the raw game assemblies.
 - Attempted to run `dotnet build src/oniMods.sln`, but the container still lacks the `.NET` host (`dotnet: command not found`). Please rebuild locally to confirm the solution consumes the publicized assemblies.

--- a/src/DevLoader/DevLoader/CenterMini.cs
+++ b/src/DevLoader/DevLoader/CenterMini.cs
@@ -179,7 +179,8 @@ public static class CenterMini
 		}
 		try
 		{
-			Sprite sprite = Assets.GetSprite(HashedString.op_Implicit(atlasKey));
+                        HashedString hashedAtlasKey = new HashedString(atlasKey);
+                        Sprite sprite = Assets.GetSprite(hashedAtlasKey);
 			Debug.Log((object)("[DevLoader][MiniCenter] Atlas  + atlasKey +  -> " + (Object.op_Implicit((Object)sprite) ? ((Object)sprite).name : "<null>")));
 			return sprite;
 		}


### PR DESCRIPTION
## Summary
- replace the implicit HashedString conversion in CenterMini with an explicit constructor before fetching the atlas sprite
- document the conversion update and the blocked local build in NOTES.md

## Testing
- `dotnet build src/DevLoader/DevLoader.csproj` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e59b3b7f0c83299c420a3c9f37f264