### PR TITLE
Qualify DevLoader delegates with System.Action

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -392,3 +392,7 @@
 ## 2025-10-07 - Directory.Build.props public assembly repointing
 - Updated `src/Directory.Build.props` so the shared ONI references resolve the `_public` DLLs generated under `src/lib`, preventing accidental fallbacks to the raw game assemblies.
 - Attempted to run `dotnet build src/oniMods.sln`, but the container still lacks the `.NET` host (`dotnet: command not found`). Please rebuild locally to confirm the solution consumes the publicized assemblies.
+## 2025-12-17 - DevLoader delegate namespace cleanup
+- Qualified the DevLoader hotkey loading callbacks and runtime toggle event with `System.Action` so the compiler binds against the BCL delegates explicitly.
+- Attempted to run `dotnet build src/DevLoader/DevLoader.csproj` to confirm the delegate changes compile, but the container still lacks the `.NET` host (`dotnet: command not found`). Please rebuild locally to verify.
+

--- a/src/DevLoader/DevLoader/Hotkeys.cs
+++ b/src/DevLoader/DevLoader/Hotkeys.cs
@@ -21,7 +21,7 @@ public class Hotkeys : MonoBehaviour
                 if ((Object)Game.Instance != null && (Object)PauseScreen.Instance != null)
 		{
 			Debug.Log((object)"[DevLoader] Ctrl+1 → Saliendo al menú sin guardar");
-			LoadingOverlay.Load((Action)delegate
+                        LoadingOverlay.Load((System.Action)delegate
 			{
 				((KScreen)PauseScreen.Instance).Deactivate();
 				PauseScreen.TriggerQuitGame();
@@ -33,7 +33,7 @@ public class Hotkeys : MonoBehaviour
 		if (!string.IsNullOrEmpty(latestSaveForCurrentDLC))
 		{
 			SaveLoader.SetActiveSaveFilePath(latestSaveForCurrentDLC);
-			LoadingOverlay.Load((Action)delegate
+                        LoadingOverlay.Load((System.Action)delegate
 			{
 				App.LoadScene("backend");
 			});

--- a/src/DevLoader/DevLoader/Runtime.cs
+++ b/src/DevLoader/DevLoader/Runtime.cs
@@ -5,7 +5,7 @@ namespace DevLoader;
 
 public static class Runtime
 {
-	public static event Action<bool> Toggled;
+        public static event System.Action<bool> Toggled;
 
 	public static void ApplyToggle(bool enabled)
 	{


### PR DESCRIPTION
## Summary
- qualify the DevLoader LoadingOverlay callbacks with System.Action so the runtime resolves the BCL delegate explicitly
- update the DevLoader toggle event to use System.Action and document the follow-up build requirement in NOTES.md

## Testing
- `dotnet build src/DevLoader/DevLoader.csproj` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e59cdaf3548329b843739a323a5d69