### PR TITLE
Replace DevLoader implicit operator usage

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -396,3 +396,7 @@
 - Qualified the DevLoader hotkey loading callbacks and runtime toggle event with `System.Action` so the compiler binds against the BCL delegates explicitly.
 - Attempted to run `dotnet build src/DevLoader/DevLoader.csproj` to confirm the delegate changes compile, but the container still lacks the `.NET` host (`dotnet: command not found`). Please rebuild locally to verify.
 
+## 2025-12-18 - DevLoader implicit operator removal follow-up
+- Replaced every `Object.op_Implicit` usage inside `CenterMini` and `DevMiniBootstrap` with explicit null checks to resolve the CS0558 compiler errors introduced by Unity's stripped implicit operators.
+- Tried to verify the fix via `dotnet build src/DevLoader/DevLoader.csproj`, but the container continues to report `command not found: dotnet`; rerun the build locally to ensure the DevLoader project compiles cleanly.
+

--- a/src/DevLoader/DevLoader/CenterMini.cs
+++ b/src/DevLoader/DevLoader/CenterMini.cs
@@ -64,7 +64,7 @@ public static class CenterMini
 		{
 			_onMini = TryLoadMini("mini_dev_on.png", "mini_dev_on");
 			_offMini = TryLoadMini("mini_dev_off.png", "mini_dev_off");
-			Debug.Log((object)("[DevLoader][MiniCenter] Sprites: on=" + (Object.op_Implicit((Object)_onMini) ? ((Object)_onMini).name : "<null>") + " off=" + (Object.op_Implicit((Object)_offMini) ? ((Object)_offMini).name : "<null>")));
+                        Debug.Log((object)("[DevLoader][MiniCenter] Sprites: on=" + (((Object)_onMini != null) ? ((Object)_onMini).name : "<null>") + " off=" + (((Object)_offMini != null) ? ((Object)_offMini).name : "<null>")));
 			Transform val2 = (((Object)parentHint != null) ? parentHint.root : null);
 			if ((Object)val2 == null && (Object)parentHint != null)
 			{
@@ -88,7 +88,7 @@ public static class CenterMini
 			_img.preserveAspect = true;
 			((Graphic)_img).color = Color.white;
 			_img.sprite = (Config.Enabled ? (_onMini ?? _offMini) : (_offMini ?? _onMini));
-			Debug.Log((object)("[DevLoader][MiniCenter] Image sprite set -> " + (Object.op_Implicit((Object)_img.sprite) ? ((Object)_img.sprite).name : "<null>")));
+                        Debug.Log((object)("[DevLoader][MiniCenter] Image sprite set -> " + (((Object)_img.sprite != null) ? ((Object)_img.sprite).name : "<null>")));
 			Button component = val3.GetComponent<Button>();
 			((Selectable)component).transition = (Transition)0;
 			((UnityEventBase)component.onClick).RemoveAllListeners();
@@ -142,7 +142,7 @@ public static class CenterMini
 		}
 		Sprite val = (Config.Enabled ? (_onMini ?? _offMini) : (_offMini ?? _onMini));
 		_img.sprite = val;
-		Debug.Log((object)("[DevLoader][MiniCenter] UpdateIcon -> " + (Config.Enabled ? "ON" : "OFF") + " sprite=" + (Object.op_Implicit((Object)val) ? ((Object)val).name : "<null>")));
+                Debug.Log((object)("[DevLoader][MiniCenter] UpdateIcon -> " + (Config.Enabled ? "ON" : "OFF") + " sprite=" + (((Object)val != null) ? ((Object)val).name : "<null>")));
 	}
 
 	private static Sprite TryLoadMini(string file, string atlasKey)
@@ -181,7 +181,7 @@ public static class CenterMini
 		{
                         HashedString hashedAtlasKey = new HashedString(atlasKey);
                         Sprite sprite = Assets.GetSprite(hashedAtlasKey);
-			Debug.Log((object)("[DevLoader][MiniCenter] Atlas  + atlasKey +  -> " + (Object.op_Implicit((Object)sprite) ? ((Object)sprite).name : "<null>")));
+                        Debug.Log((object)("[DevLoader][MiniCenter] Atlas  + atlasKey +  -> " + (((Object)sprite != null) ? ((Object)sprite).name : "<null>")));
 			return sprite;
 		}
 		catch (Exception ex2)

--- a/src/DevLoader/DevLoader/DevMiniBootstrap.cs
+++ b/src/DevLoader/DevLoader/DevMiniBootstrap.cs
@@ -70,7 +70,7 @@ internal sealed class DevMiniBootstrap : MonoBehaviour
 		try
 		{
 			Transform val = FindIngameParent();
-			Debug.Log((object)("[DevLoader][MiniCenter] TryInstallNow parent=" + (Object.op_Implicit((Object)val) ? ((Object)val).name : "<null>")));
+                        Debug.Log((object)("[DevLoader][MiniCenter] TryInstallNow parent=" + (((Object)val != null) ? ((Object)val).name : "<null>")));
 			if ((Object)val != null)
 			{
 				CenterMini.Ensure(val);


### PR DESCRIPTION
## Summary
- swap the remaining `Object.op_Implicit` logging helpers in CenterMini for explicit null checks
- update DevMiniBootstrap to log the discovered parent via a direct null test
- document the implicit-operator cleanup and note the blocked build in `NOTES.md`

## Testing
- `dotnet build src/DevLoader/DevLoader.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68e59e17cab883298180487103aa2cc5