### PR TITLE
Align DevLoader button UI types

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -400,3 +400,7 @@
 - Replaced every `Object.op_Implicit` usage inside `CenterMini` and `DevMiniBootstrap` with explicit null checks to resolve the CS0558 compiler errors introduced by Unity's stripped implicit operators.
 - Tried to verify the fix via `dotnet build src/DevLoader/DevLoader.csproj`, but the container continues to report `command not found: dotnet`; rerun the build locally to ensure the DevLoader project compiles cleanly.
 
+## 2025-12-19 - DevLoader Unity UI API alignment
+- Updated `CenterMini` to use `Selectable.Transition.None` and `Button.ButtonClickedEvent` so the generated IL no longer depends on deprecated Unity UI type aliases.
+- Attempted to rebuild with `dotnet build src/DevLoader/DevLoader.csproj`, but the container still lacks the `.NET` host (`command not found: dotnet`). Please rerun the build locally to confirm the Unity UI references resolve correctly.
+

--- a/src/DevLoader/DevLoader/CenterMini.cs
+++ b/src/DevLoader/DevLoader/CenterMini.cs
@@ -90,9 +90,9 @@ public static class CenterMini
 			_img.sprite = (Config.Enabled ? (_onMini ?? _offMini) : (_offMini ?? _onMini));
                         Debug.Log((object)("[DevLoader][MiniCenter] Image sprite set -> " + (((Object)_img.sprite != null) ? ((Object)_img.sprite).name : "<null>")));
 			Button component = val3.GetComponent<Button>();
-			((Selectable)component).transition = (Transition)0;
-			((UnityEventBase)component.onClick).RemoveAllListeners();
-			ButtonClickedEvent onClick = component.onClick;
+                        ((Selectable)component).transition = Selectable.Transition.None;
+                        ((UnityEventBase)component.onClick).RemoveAllListeners();
+                        Button.ButtonClickedEvent onClick = component.onClick;
 			object obj2 = _003C_003Ec._003C_003E9__3_0;
 			if (obj2 == null)
 			{


### PR DESCRIPTION
## Summary
- replace CenterMini's manual transition cast with Selectable.Transition.None
- qualify the button click event type with UnityEngine.UI.Button.ButtonClickedEvent
- document the change and blocked build attempt in NOTES.md for follow-up

## Testing
- `dotnet build src/DevLoader/DevLoader.csproj` *(fails: command not found: dotnet in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e59ebf6c988329a0ce5d972f6b256d