### PR TITLE
Use predicate matcher in BetterDeselect transpilers

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -404,3 +404,6 @@
 - Updated `CenterMini` to use `Selectable.Transition.None` and `Button.ButtonClickedEvent` so the generated IL no longer depends on deprecated Unity UI type aliases.
 - Attempted to rebuild with `dotnet build src/DevLoader/DevLoader.csproj`, but the container still lacks the `.NET` host (`command not found: dotnet`). Please rerun the build locally to confirm the Unity UI references resolve correctly.
 
+## 2025-12-20 - BetterDeselect transpiler predicate update
+- Swapped the `Manipulator` matchers in the BetterDeselect escape-close patches to use predicate-based overloads so Harmony's `Calls` helper drives the injection target.
+- Attempted to validate with `dotnet build src/oniMods.sln`, but the container still lacks the `.NET` host (`command not found: dotnet`). Please rerun the build locally to confirm the transpiler updates compile.

--- a/src/BetterDeselect/Deselect/EscapeCloseAll_Patches.cs
+++ b/src/BetterDeselect/Deselect/EscapeCloseAll_Patches.cs
@@ -10,7 +10,7 @@ namespace BetterDeselect.Deselect
     {
         static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
         {
-            return instructions.Manipulator(AccessTools.Method(typeof(SelectTool), nameof(SelectTool.Activate)), AddMethod);
+            return instructions.Manipulator(i => i.Calls(AccessTools.Method(typeof(SelectTool), nameof(SelectTool.Activate))), AddMethod);
 
             IEnumerable<CodeInstruction> AddMethod(CodeInstruction i)
             {
@@ -32,7 +32,7 @@ namespace BetterDeselect.Deselect
     {
         static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
         {
-            return instructions.Manipulator(AccessTools.Method(typeof(SelectTool), nameof(SelectTool.Activate)), AddMethod);
+            return instructions.Manipulator(i => i.Calls(AccessTools.Method(typeof(SelectTool), nameof(SelectTool.Activate))), AddMethod);
 
             IEnumerable<CodeInstruction> AddMethod(CodeInstruction i)
             {


### PR DESCRIPTION
## Summary
- switch the BetterDeselect escape-close transpilers to the predicate overload of Manipulator so the Calls helper identifies the SelectTool.Activate instruction
- record the Harmony matcher update and blocked build verification in NOTES

## Testing
- `dotnet build src/oniMods.sln` *(fails: command not found: dotnet in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5a02b045c8329ba2d9d531cd7ff57