### PR TITLE
Make AMonoBehaviour OnSpawn virtual

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -407,3 +407,7 @@
 ## 2025-12-20 - BetterDeselect transpiler predicate update
 - Swapped the `Manipulator` matchers in the BetterDeselect escape-close patches to use predicate-based overloads so Harmony's `Calls` helper drives the injection target.
 - Attempted to validate with `dotnet build src/oniMods.sln`, but the container still lacks the `.NET` host (`command not found: dotnet`). Please rerun the build locally to confirm the transpiler updates compile.
+
+## 2025-12-21 - AMonoBehaviour spawn hook virtualization
+- Marked `AMonoBehaviour.OnSpawn()` as `virtual` so derived components such as `LogicLabelSetting` can extend the spawn sequence while retaining the automatic `[MyCmpGet]` cache population.
+- Tried to rebuild with `dotnet build src/BetterLogicOverlay/BetterLogicOverlay.csproj`, but the container still lacks the `.NET` host (`command not found: dotnet`). Please rerun the project build locally to confirm the new override compiles cleanly.

--- a/src/AzeLib/Attributes/AMonoBehaviour.cs
+++ b/src/AzeLib/Attributes/AMonoBehaviour.cs
@@ -24,7 +24,7 @@ namespace AzeLib.Attributes
         /// <returns>The component instance that should be assigned to the field.</returns>
         protected virtual object? ResolveComponent(Type componentType) => GetComponent(componentType);
 
-        public void OnSpawn()
+        public virtual void OnSpawn()
         {
             var thisType = GetType();
             var cachedFields = MyIntGetFieldCache.GetOrAdd(thisType, BuildMyIntGetFieldCache);


### PR DESCRIPTION
## Summary
- mark `AMonoBehaviour.OnSpawn()` as `virtual` so derived components can extend the spawn hook without losing the `[MyCmpGet]` caching
- note the BetterLogicOverlay `LogicLabelSetting` override already calls `base.OnSpawn()` to keep the cache population intact
- document the change and the skipped build in `NOTES.md`

## Testing
- `dotnet build src/BetterLogicOverlay/BetterLogicOverlay.csproj` *(fails: `dotnet` host not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5a1483eb48329b68471dfce6d1940