### PR TITLE
Make AMonoBehaviour spawn hook overridable

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -159,6 +159,10 @@
 - Added a replay-phase fallback in the widget postfix to lazily create the container when the prefix is bypassed, keeping the `IsInterceptMode` guard so live draws remain untouched.
 - The ONI-managed assemblies and runtime are still unavailable here, so `dotnet build src/oniMods.sln` and in-game hover validation of multi-column wrapping must be performed in a full environment.
 
+## 2025-11-02 - AzeLib spawn hook virtualization
+- Updated `AMonoBehaviour.OnSpawn` to be virtual so mods like BetterLogicOverlay can override the spawn hook while preserving the attribute-driven component resolution.
+- Attempted `dotnet build src/oniMods.sln`, but the container image still lacks the .NET host (`dotnet` command is unavailable). Rebuild the solution in a full ONI environment to confirm the override compiles.
+
 ## 2025-11-02 - BetterInfoCards hover drawer null guards
 - Hardened the hover drawer patches so every `DrawIcon`, `DrawText`, `AddIndent`, `NewLine`, and `EndShadowBar` prefix verifies `curInfoCard` before replaying captured actions, logging and deferring to vanilla rendering when the card context is missing.
 - Reset `curInfoCard` whenever `BeginShadowBar` skips allocation to avoid replaying into a stale card when the intercept path is bypassed.

--- a/src/AzeLib/Attributes/AMonoBehaviour.cs
+++ b/src/AzeLib/Attributes/AMonoBehaviour.cs
@@ -24,7 +24,7 @@ namespace AzeLib.Attributes
         /// <returns>The component instance that should be assigned to the field.</returns>
         protected virtual object? ResolveComponent(Type componentType) => GetComponent(componentType);
 
-        public void OnSpawn()
+        public virtual void OnSpawn()
         {
             var thisType = GetType();
             var cachedFields = MyIntGetFieldCache.GetOrAdd(thisType, BuildMyIntGetFieldCache);


### PR DESCRIPTION
## Summary
- declare `AMonoBehaviour.OnSpawn` as virtual so mods can override the spawn hook
- document the change and the blocked local rebuild in `NOTES.md`

## Testing
- `dotnet build src/oniMods.sln` *(fails: command not found: dotnet in container image)*

------
https://chatgpt.com/codex/tasks/task_e_68e5a6b3b8948329b53f2f6277e60f51