### PR TITLE
Adjust BetterLogicOverlay manipulator predicate

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,5 +1,9 @@
 # AzeLib OnLoad benchmark (2024-06-17)
 
+## 2025-12-21 - BetterLogicOverlay IsBitActive predicate update
+- Updated `GateColorOutput_Patch` to use Harmony's predicate-based `Manipulator` overload when targeting `LogicCircuitNetwork.IsBitActive`, preventing delegate signature mismatches when Harmony resolves the hook.
+- Attempted to validate with `dotnet build src/BetterLogicOverlay/BetterLogicOverlay.csproj`, but the container still lacks the `.NET` host (`command not found: dotnet`). Please rebuild locally to confirm the predicate change compiles without errors.
+
 ## Instrumentation
 - Added DEBUG-only diagnostics around `AzeUserMod.OnLoad` to log discovery, invocation, and total execution timing without affecting release builds.
 - Reflection-based discovery results are now cached so domain reloads reuse the same `OnLoad` metadata instead of re-scanning the assembly.

--- a/src/BetterLogicOverlay/GateColorOutput_Patch.cs
+++ b/src/BetterLogicOverlay/GateColorOutput_Patch.cs
@@ -12,8 +12,10 @@ namespace BetterLogicOverlay
 
         static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
         {
+            var targetMethod = AccessTools.Method(typeof(LogicCircuitNetwork), nameof(LogicCircuitNetwork.IsBitActive), new[] { typeof(int) });
+
             return instructions.Manipulator(
-                AccessTools.Method(typeof(LogicCircuitNetwork), nameof(LogicCircuitNetwork.IsBitActive), new[] { typeof(int) }),
+                i => i.Calls(targetMethod),
                 ReplaceWithWrapper);
 
             IEnumerable<CodeInstruction> ReplaceWithWrapper(CodeInstruction i)


### PR DESCRIPTION
## Summary
- update the BetterLogicOverlay gate color transpiler to use the predicate-based Manipulator overload when targeting LogicCircuitNetwork.IsBitActive
- record the predicate change and blocked build validation in NOTES.md for follow-up

## Testing
- dotnet build src/BetterLogicOverlay/BetterLogicOverlay.csproj *(fails: command not found: dotnet in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5a910927c83299500d1f84a192d71