### PR TITLE
Fix broadcaster label component lookup

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -415,3 +415,7 @@
 ## 2025-12-20 - BetterDeselect transpiler predicate update
 - Swapped the `Manipulator` matchers in the BetterDeselect escape-close patches to use predicate-based overloads so Harmony's `Calls` helper drives the injection target.
 - Attempted to validate with `dotnet build src/oniMods.sln`, but the container still lacks the `.NET` host (`command not found: dotnet`). Please rerun the build locally to confirm the transpiler updates compile.
+
+## 2025-12-21 - BetterLogicOverlay broadcaster label component fetch
+- Injected a `[MyCmpGet]` field into `LogicBroadcasterSetting` so the label resolves the broadcaster's display name without using the component instance as a `KMonoBehaviour`.
+- Tried to rebuild with `dotnet build src/BetterLogicOverlay/BetterLogicOverlay.csproj` to confirm the missing `KMonoBehaviour` conversion error is resolved, but the container still lacks the `.NET` host (`command not found: dotnet`). Please rerun the build locally to verify.

--- a/src/BetterLogicOverlay/LogicLabelSettings/Specific/LogicBroadcasterSetting.cs
+++ b/src/BetterLogicOverlay/LogicLabelSettings/Specific/LogicBroadcasterSetting.cs
@@ -1,8 +1,12 @@
-﻿namespace BetterLogicOverlay.LogicSettingDisplay
+using AzeLib.Attributes;
+
+namespace BetterLogicOverlay.LogicSettingDisplay
 {
     class LogicBroadcasterSetting : LogicLabelSetting
     {
-        public override string GetSetting() => GetString(this);
+        [MyCmpGet] private LogicBroadcaster logicBroadcaster;
+
+        public override string GetSetting() => GetString(logicBroadcaster);
 
         protected string GetString(KMonoBehaviour l) => l.GetProperName();
 


### PR DESCRIPTION
## Summary
- add a MyCmpGet field to LogicBroadcasterSetting so the broadcaster name resolves without using the component instance as a KMonoBehaviour
- document the attempted BetterLogicOverlay rebuild that is blocked by the missing dotnet host

## Testing
- dotnet build src/BetterLogicOverlay/BetterLogicOverlay.csproj *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68e5a9b6977c832992fdeabaa1e6dc06