### PR TITLE
Fix door spawn opener visibility

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,5 +1,12 @@
 # AzeLib OnLoad benchmark (2024-06-17)
 
+## 2025-12-22 - DefaultBuildingSettings door spawn visibility
+- Updated `DoorSpawnOpener`'s `OnSpawn` override visibility to `public` so Unity can invoke it when Harmony injects the helper
+  component onto door prefabs during construction.
+- Attempted to rebuild with `dotnet build src/DefaultBuildingSettings/DefaultBuildingSettings.csproj`, but the container still
+  lacks the `.NET` host (`command not found: dotnet`). Please rerun the build locally to confirm the accessibility change resolv
+es the visibility compiler error.
+
 ## 2025-12-21 - BetterLogicOverlay IsBitActive predicate update
 - Updated `GateColorOutput_Patch` to use Harmony's predicate-based `Manipulator` overload when targeting `LogicCircuitNetwork.IsBitActive`, preventing delegate signature mismatches when Harmony resolves the hook.
 - Attempted to validate with `dotnet build src/BetterLogicOverlay/BetterLogicOverlay.csproj`, but the container still lacks the `.NET` host (`command not found: dotnet`). Please rebuild locally to confirm the predicate change compiles without errors.

--- a/src/DefaultBuildingSettings/OnBuild_Patch.cs
+++ b/src/DefaultBuildingSettings/OnBuild_Patch.cs
@@ -64,7 +64,7 @@ namespace DefaultBuildingSettings
         {
             [MyCmpReq] private Door door;
 
-            protected override void OnSpawn()
+            public override void OnSpawn()
             {
                 base.OnSpawn();
 


### PR DESCRIPTION
## Summary
- expose `DoorSpawnOpener.OnSpawn` so Unity can invoke the helper component when doors spawn
- document the follow-up build verification needed because the container lacks the .NET host

## Testing
- dotnet build src/DefaultBuildingSettings/DefaultBuildingSettings.csproj *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68e5abbf442c832993fdb0ceb4fd81e7