### PR TITLE
Remove hard-coded Assembly-CSharp reference

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,5 +1,9 @@
 # AzeLib OnLoad benchmark (2024-06-17)
 
+## 2025-12-22 - SuppressNotifications reference cleanup
+- Removed the hard-coded `Assembly-CSharp.dll` reference from `SuppressNotifications.csproj` so the project now inherits the `_public` assemblies through `Directory.Build.props`.
+- Attempted to rebuild with `dotnet build src/SuppressNotifications/SuppressNotifications.csproj` to confirm `Assets.CreatePrefabs` resolves under the shared references, but the container still lacks the `.NET` host (`command not found: dotnet`). Please rerun the build locally once the ONI toolchain is available to verify compilation succeeds.
+
 ## 2025-12-22 - DefaultBuildingSettings door spawn visibility
 - Updated `DoorSpawnOpener`'s `OnSpawn` override visibility to `public` so Unity can invoke it when Harmony injects the helper
   component onto door prefabs during construction.

--- a/src/SuppressNotifications/SuppressNotifications.csproj
+++ b/src/SuppressNotifications/SuppressNotifications.csproj
@@ -7,9 +7,4 @@
     <Title>Suppress Notifications</Title>
     <Description>Suppresses notifications and status items from individual buildings/critters/plants.</Description>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Assembly-CSharp">
-      <HintPath>F:\SteamLibrary\steamapps\common\OxygenNotIncluded\OxygenNotIncluded_Data\Managed\Assembly-CSharp.dll</HintPath>
-    </Reference>
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- remove the direct Assembly-CSharp.dll reference from SuppressNotifications so it consumes the shared Directory.Build.props references
- document the change and the missing-dotnet build gap in NOTES.md

## Testing
- `dotnet build src/SuppressNotifications/SuppressNotifications.csproj` *(fails: command not found: dotnet in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5ad5675e4832988c1bde3358d45d1