### PR TITLE
Adjust CopyEntitySettingsTool override scope

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -4,6 +4,10 @@
 - Removed the hard-coded `Assembly-CSharp.dll` reference from `SuppressNotifications.csproj` so the project now inherits the `_public` assemblies through `Directory.Build.props`.
 - Attempted to rebuild with `dotnet build src/SuppressNotifications/SuppressNotifications.csproj` to confirm `Assets.CreatePrefabs` resolves under the shared references, but the container still lacks the `.NET` host (`command not found: dotnet`). Please rerun the build locally once the ONI toolchain is available to verify compilation succeeds.
 
+## 2025-12-23 - SuppressNotifications copy tool override scope
+- Narrowed the override visibility for `CopyEntitySettingsTool` so `DragTool` lifecycle hooks remain protected and Unity can continue invoking them through the base type.
+- Attempted to rebuild with `dotnet build src/SuppressNotifications/SuppressNotifications.csproj`, but the container still lacks the `.NET` host (`command not found: dotnet`). Please rerun the build locally once the ONI toolchain is available to confirm the access modifier adjustments compile without warnings.
+
 ## 2025-12-22 - DefaultBuildingSettings door spawn visibility
 - Updated `DoorSpawnOpener`'s `OnSpawn` override visibility to `public` so Unity can invoke it when Harmony injects the helper
   component onto door prefabs during construction.

--- a/src/SuppressNotifications/UI/Entities/CopyEntitySettingsTool/CopyEntitySettingsTool.cs
+++ b/src/SuppressNotifications/UI/Entities/CopyEntitySettingsTool/CopyEntitySettingsTool.cs
@@ -16,7 +16,7 @@ namespace SuppressNotifications
         public void SetSourceObject(GameObject go) => sourceGameObject = go;
         public void Activate() => PlayerController.Instance.ActivateTool(this);
 
-        public override void OnPrefabInit()
+        protected override void OnPrefabInit()
         {
             // Initialize
             base.OnPrefabInit();
@@ -46,7 +46,7 @@ namespace SuppressNotifications
             hoverConfig.ToolName = hoverTemplate.ToolName;
         }
 
-        public override void OnDragTool(int cell, int distFromOrigin)
+        protected override void OnDragTool(int cell, int distFromOrigin)
         {
             if (sourceGameObject == null)
                 return;
@@ -55,7 +55,7 @@ namespace SuppressNotifications
                 cells.Add(cell);
         }
 
-        public override void OnDragComplete(Vector3 cursorDown, Vector3 cursorUp)
+        protected override void OnDragComplete(Vector3 cursorDown, Vector3 cursorUp)
         {
             if (sourceGameObject.GetComponent<CreatureBrain>() != null)
                 CopyCritterSettings();
@@ -67,13 +67,13 @@ namespace SuppressNotifications
                 CopyGeyserSettings();
         }
 
-        public override void OnLeftClickDown(Vector3 cursor_pos)
+        protected override void OnLeftClickDown(Vector3 cursor_pos)
         {
             base.OnLeftClickDown(cursor_pos);
             cells.Clear();
         }
 
-        public override void OnDeactivateTool(InterfaceTool new_tool)
+        protected override void OnDeactivateTool(InterfaceTool new_tool)
         {
             base.OnDeactivateTool(new_tool);
             sourceGameObject = null;


### PR DESCRIPTION
## Summary
- switch CopyEntitySettingsTool's DragTool lifecycle overrides back to protected visibility
- document the visibility fix and the blocked rebuild in NOTES

## Testing
- `dotnet build src/SuppressNotifications/SuppressNotifications.csproj` *(fails: command not found; container lacks .NET toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_68e5ade06fbc8329a2d38c2472fefdaf