### PR TITLE
Fix CopyEntitySettingsTool overrides to match DragTool

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -5,7 +5,7 @@
 - Attempted to rebuild with `dotnet build src/SuppressNotifications/SuppressNotifications.csproj` to confirm `Assets.CreatePrefabs` resolves under the shared references, but the container still lacks the `.NET` host (`command not found: dotnet`). Please rerun the build locally once the ONI toolchain is available to verify compilation succeeds.
 
 ## 2025-12-23 - SuppressNotifications copy tool override scope
-- Narrowed the override visibility for `CopyEntitySettingsTool` so `DragTool` lifecycle hooks remain protected and Unity can continue invoking them through the base type.
+- Widened the override visibility for `CopyEntitySettingsTool`'s drag lifecycle hooks to `public` so they match `DragTool`'s declarations and clear the CS0507 accessibility mismatch.
 - Attempted to rebuild with `dotnet build src/SuppressNotifications/SuppressNotifications.csproj`, but the container still lacks the `.NET` host (`command not found: dotnet`). Please rerun the build locally once the ONI toolchain is available to confirm the access modifier adjustments compile without warnings.
 
 ## 2025-12-22 - DefaultBuildingSettings door spawn visibility

--- a/src/SuppressNotifications/UI/Entities/CopyEntitySettingsTool/CopyEntitySettingsTool.cs
+++ b/src/SuppressNotifications/UI/Entities/CopyEntitySettingsTool/CopyEntitySettingsTool.cs
@@ -16,7 +16,7 @@ namespace SuppressNotifications
         public void SetSourceObject(GameObject go) => sourceGameObject = go;
         public void Activate() => PlayerController.Instance.ActivateTool(this);
 
-        protected override void OnPrefabInit()
+        public override void OnPrefabInit()
         {
             // Initialize
             base.OnPrefabInit();
@@ -46,7 +46,7 @@ namespace SuppressNotifications
             hoverConfig.ToolName = hoverTemplate.ToolName;
         }
 
-        protected override void OnDragTool(int cell, int distFromOrigin)
+        public override void OnDragTool(int cell, int distFromOrigin)
         {
             if (sourceGameObject == null)
                 return;
@@ -55,7 +55,7 @@ namespace SuppressNotifications
                 cells.Add(cell);
         }
 
-        protected override void OnDragComplete(Vector3 cursorDown, Vector3 cursorUp)
+        public override void OnDragComplete(Vector3 cursorDown, Vector3 cursorUp)
         {
             if (sourceGameObject.GetComponent<CreatureBrain>() != null)
                 CopyCritterSettings();
@@ -67,13 +67,13 @@ namespace SuppressNotifications
                 CopyGeyserSettings();
         }
 
-        protected override void OnLeftClickDown(Vector3 cursor_pos)
+        public override void OnLeftClickDown(Vector3 cursor_pos)
         {
             base.OnLeftClickDown(cursor_pos);
             cells.Clear();
         }
 
-        protected override void OnDeactivateTool(InterfaceTool new_tool)
+        public override void OnDeactivateTool(InterfaceTool new_tool)
         {
             base.OnDeactivateTool(new_tool);
             sourceGameObject = null;


### PR DESCRIPTION
## Summary
- make the CopyEntitySettingsTool lifecycle overrides public to align with DragTool and clear the CS0507 accessibility errors
- document the accessibility fix and blocked build attempt in NOTES.md

## Testing
- `dotnet build src/SuppressNotifications/SuppressNotifications.csproj` *(fails: command not found: dotnet in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5af124f688329a3fc6a89f89866e9