### PR TITLE
Qualify SuppressNotifications UI strings

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -434,3 +434,8 @@ es the visibility compiler error.
 ## 2025-12-21 - BetterLogicOverlay broadcaster label component fetch
 - Injected a `[MyCmpGet]` field into `LogicBroadcasterSetting` so the label resolves the broadcaster's display name without using the component instance as a `KMonoBehaviour`.
 - Tried to rebuild with `dotnet build src/BetterLogicOverlay/BetterLogicOverlay.csproj` to confirm the missing `KMonoBehaviour` conversion error is resolved, but the container still lacks the `.NET` host (`command not found: dotnet`). Please rerun the build locally to verify.
+
+
+## 2025-12-22 - SuppressNotifications string namespace qualification
+- Qualified the SuppressNotifications copy tools to use the game UI namespace aliases so the compiler resolves `STRINGS.UI` correctly.
+- Attempted to rebuild with `dotnet build src/SuppressNotifications/SuppressNotifications.csproj`, but the container still lacks the `.NET` host (`dotnet: command not found`). Please rerun the build locally to confirm the namespace bindings compile.

--- a/src/SuppressNotifications/UI/Entities/CopyEntitySettingsTool/CopyEntitySettings.cs
+++ b/src/SuppressNotifications/UI/Entities/CopyEntitySettingsTool/CopyEntitySettings.cs
@@ -1,6 +1,7 @@
 ﻿using UnityEngine;
 using STRINGS;
 using System;
+using StringsUI = global::STRINGS.UI;
 
 namespace SuppressNotifications
 {
@@ -17,10 +18,10 @@ namespace SuppressNotifications
             UserMenu userMenu = Game.Instance.userMenu;
             GameObject gameObject = base.gameObject;
             string iconName = "action_mirror";
-            string text = UI.USERMENUACTIONS.COPY_BUILDING_SETTINGS.NAME;
+            string text = StringsUI.USERMENUACTIONS.COPY_BUILDING_SETTINGS.NAME;
             var on_click = new System.Action(ActivateCopyTool);
             Enum.TryParse(nameof(Action.BuildingUtility1), out Action shortcutKey);
-            string tooltipText = UI.USERMENUACTIONS.COPY_BUILDING_SETTINGS.TOOLTIP;
+            string tooltipText = StringsUI.USERMENUACTIONS.COPY_BUILDING_SETTINGS.TOOLTIP;
             userMenu.AddButton(gameObject, new KIconButtonMenu.ButtonInfo(iconName, text, on_click, shortcutKey, null, null, null, tooltipText, true), 1f);
         }
 

--- a/src/SuppressNotifications/UI/Entities/CopyEntitySettingsTool/CopyEntitySettingsTool.cs
+++ b/src/SuppressNotifications/UI/Entities/CopyEntitySettingsTool/CopyEntitySettingsTool.cs
@@ -1,4 +1,5 @@
 ﻿using STRINGS;
+using StringsUI = global::STRINGS.UI;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -96,7 +97,7 @@ namespace SuppressNotifications
             void CopyTo(GameObject go)
             {
                 go.Trigger((int)GameHashes.CopySettings, sourceGameObject);
-                PopFXManager.Instance.SpawnFX(PopFXManager.Instance.sprite_Plus, UI.COPIED_SETTINGS, go.transform, new Vector3(0f, 0.5f, 0f), 1.5f, false, false);
+                PopFXManager.Instance.SpawnFX(PopFXManager.Instance.sprite_Plus, StringsUI.COPIED_SETTINGS, go.transform, new Vector3(0f, 0.5f, 0f), 1.5f, false, false);
             }
         }
     }

--- a/src/SuppressNotifications/Util/STRINGS.cs
+++ b/src/SuppressNotifications/Util/STRINGS.cs
@@ -1,5 +1,6 @@
 ﻿using AzeLib;
 using STRINGS;
+using StringsUI = global::STRINGS.UI;
 
 namespace SuppressNotifications
 {
@@ -11,13 +12,13 @@ namespace SuppressNotifications
         public class SUPPRESSBUTTON
         {
             public static LocString NAME = "Suppress Current";
-            public static LocString TOOLTIP = UI.FormatAsKeyWord("Suppress") + " the following items.";
+            public static LocString TOOLTIP = StringsUI.FormatAsKeyWord("Suppress") + " the following items.";
         }
 
         public class CLEARBUTTON
         {
             public static LocString NAME = "Clear Suppressed";
-            public static LocString TOOLTIP = UI.FormatAsKeyWord("Stop suppressing") + " the following items.";
+            public static LocString TOOLTIP = StringsUI.FormatAsKeyWord("Stop suppressing") + " the following items.";
         }
 
         public class BUILDINGS


### PR DESCRIPTION
## Summary
- Qualify the SuppressNotifications copy tool string references against STRINGS.UI so the compiler binds to the game namespace.
- Update the SuppressNotifications string helpers to invoke the STRINGS.UI keyword formatter explicitly.

## Testing
- `dotnet build src/SuppressNotifications/SuppressNotifications.csproj` *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5b09d8d348329ac3b60add27390b6