### PR TITLE
Guard AzeLib OnLoad against null assembly

### DIFF
--- a/ERRORS.md
+++ b/ERRORS.md
@@ -59,3 +59,9 @@
 - **Resolution:** Removed the redundant `<Reference>` entries so DevLoader now inherits the managed assembly references from the shared build targets.
 - **Status:** Fixed
 
+## 2025-12-24 - AzeLib OnLoad assembly fallback
+- **Module:** AzeLib bootstrap sequencing
+- **Issue:** `UserMod2.assembly` may be `null` during some reload paths, causing `AzeUserMod.OnLoad` to throw while logging the version or discovering `[OnLoad]` hooks via reflection.
+- **Resolution:** Capture the module assembly via `assembly ?? GetType().Assembly` and reuse it for logging and reflection, guarding all accesses that previously relied on `UserMod.assembly`.
+- **Status:** Fixed
+

--- a/NOTES.md
+++ b/NOTES.md
@@ -8,6 +8,10 @@
 - Widened the override visibility for `CopyEntitySettingsTool`'s drag lifecycle hooks to `public` so they match `DragTool`'s declarations and clear the CS0507 accessibility mismatch.
 - Attempted to rebuild with `dotnet build src/SuppressNotifications/SuppressNotifications.csproj`, but the container still lacks the `.NET` host (`command not found: dotnet`). Please rerun the build locally once the ONI toolchain is available to confirm the access modifier adjustments compile without warnings.
 
+## 2025-12-24 - AzeLib OnLoad assembly fallback
+- Guarded `AzeUserMod.OnLoad` against `UserMod2.assembly` being `null` by capturing `assembly ?? GetType().Assembly` for version logging and `[OnLoad]` discovery so domain reloads no longer throw.
+- Attempted to run `dotnet build src/DevLoader/DevLoader.csproj` to satisfy the DevLoader rebuild requirement, but the container still reports `command not found: dotnet`. Please rebuild locally and verify the reload loop remains clean in `Player.log` once the ONI toolchain is available.
+
 ## 2025-12-22 - DefaultBuildingSettings door spawn visibility
 - Updated `DoorSpawnOpener`'s `OnSpawn` override visibility to `public` so Unity can invoke it when Harmony injects the helper
   component onto door prefabs during construction.

--- a/src/AzeLib/AzeMod.cs
+++ b/src/AzeLib/AzeMod.cs
@@ -85,14 +85,16 @@ namespace AzeLib
             public override void OnLoad(Harmony harmony)
             {
                 UserMod = this;
-                Debug.Log("    - version: " + UserMod.assembly.GetName().Version);
+                var modAssembly = assembly ?? GetType().Assembly;
+
+                Debug.Log("    - version: " + modAssembly.GetName().Version);
 #if DEBUG
                 Debug.Log("[AzeLib] OnLoad diagnostics enabled.");
                 var totalStopwatch = Stopwatch.StartNew();
 #endif
                 PUtil.InitLibrary(false);
 
-                var (onLoadMethods, usedCache, discoveryDuration) = GetOnLoadMethods(assembly);
+                var (onLoadMethods, usedCache, discoveryDuration) = GetOnLoadMethods(modAssembly);
 
 #if DEBUG
                 Debug.Log($"[AzeLib] Discovered {onLoadMethods.Count} OnLoad methods {(usedCache ? "from cache" : "via reflection")} in {discoveryDuration.TotalMilliseconds:F2} ms.");


### PR DESCRIPTION
## Summary
- capture the AzeLib user mod assembly via a fallback so version logging works even when UserMod2.assembly is null
- reuse the resolved assembly for OnLoad reflection to keep reload discovery stable
- document the fix and the blocked DevLoader rebuild attempt in the repository logs

## Testing
- `dotnet build src/DevLoader/DevLoader.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68e5b977711c832994b66e819f301bb4