### PR TITLE
Preload DevLoader static content before running mod assemblies

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -447,3 +447,7 @@ es the visibility compiler error.
 ## 2025-12-22 - SuppressNotifications string namespace qualification
 - Qualified the SuppressNotifications copy tools to use the game UI namespace aliases so the compiler resolves `STRINGS.UI` correctly.
 - Attempted to rebuild with `dotnet build src/SuppressNotifications/SuppressNotifications.csproj`, but the container still lacks the `.NET` host (`dotnet: command not found`). Please rerun the build locally to confirm the namespace bindings compile.
+
+## 2025-12-23 - DevLoader static content preload
+- Captured each mod DLL's root and added a reflection-based `KMod.Content` loader so static assets (strings, anims, templates) register before `OnLoad` executes.
+- Attempted to verify with `dotnet build src/DevLoader/DevLoader.csproj`, but the container still lacks the `.NET` host (`dotnet: command not found`). Please rebuild locally to ensure the helper compiles alongside the new preload workflow.


### PR DESCRIPTION
## Summary
- capture each mod DLL's root directory during DevLoader's discovery loop
- reflect into KMod.Content to invoke Load/LoadAll so strings, anims, and templates register before OnLoad executes
- document the static-content preload change and the missing dotnet toolchain in NOTES.md for follow-up builds

## Testing
- not run (dotnet host is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e5bffc645c8329b30d8918b4fc110d