### PR TITLE
ContainerTooltips: refresh tooltip caches on storage change

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -16,6 +16,11 @@
 - Added a pre-load guard in `LiveLoader.LoadAll` that checks `AppDomain.CurrentDomain` for an existing assembly name match before shadow-loading development DLLs, preventing duplicate Harmony registrations for mods the core manager already imported.
 - Tried to rebuild with `dotnet build src/DevLoader/DevLoader.csproj` to confirm the guard compiles, but the container still lacks the `.NET` host (`command not found: dotnet`). Please rerun the build locally to validate the DevLoader changes.
 
+## 2025-12-24 - ContainerTooltips storage tooltip refresh
+- Ported the event-driven `StorageContentsBehaviour` and cache helpers so tooltips invalidate and rebuild per storage component instead of per-array snapshots.
+- Adjusted the summarizer and storage spawn patch to operate on a single `Storage` component, matching the refreshed behaviour contract.
+- Manual verification in-game (adding/removing storage items to observe tooltip refreshes) remains blocked here because the container lacks the ONI runtime; please validate on a workstation with the game installed.
+
 ## 2025-12-22 - DefaultBuildingSettings door spawn visibility
 - Updated `DoorSpawnOpener`'s `OnSpawn` override visibility to `public` so Unity can invoke it when Harmony injects the helper
   component onto door prefabs during construction.

--- a/Oni_mods_by_Identifier/ContainerTooltips/Options.cs
+++ b/Oni_mods_by_Identifier/ContainerTooltips/Options.cs
@@ -44,6 +44,7 @@ namespace ContainerTooltips
         {
             // Update the singleton Options.Instance when options are changed in the menu, so we don't need to restart the game.
             instance = POptions.ReadSettings<Options>() ?? new Options();
+            UserMod.ClearSummaryCache();
         }
 
         public IEnumerable<IOptionsEntry> CreateOptions()

--- a/Oni_mods_by_Identifier/ContainerTooltips/Patches/Storage/OnSpawn.cs
+++ b/Oni_mods_by_Identifier/ContainerTooltips/Patches/Storage/OnSpawn.cs
@@ -1,4 +1,5 @@
 using HarmonyLib;
+using UnityEngine;
 
 namespace ContainerTooltips
 {
@@ -14,7 +15,7 @@ namespace ContainerTooltips
                 return;
             }
 
-            // Add our custom behavior to the storage game object, which has its own OnSpawn, OnCleanUp, etc that it will use to manage the status item
+            // Attach the behaviour so it can supply this storage component directly to the status item callbacks.
             __instance.gameObject.AddOrGet<StorageContentsBehaviour>();
 
             // Debug.Log($"[ContainerTooltips]: StorageContentsBehaviour ensured on {__instance.name}");

--- a/Oni_mods_by_Identifier/ContainerTooltips/StorageContentsSummarizer.cs
+++ b/Oni_mods_by_Identifier/ContainerTooltips/StorageContentsSummarizer.cs
@@ -8,17 +8,17 @@ namespace ContainerTooltips
 {
     public static class StorageContentsSummarizer
     {
-        public static string SummarizeStorageContents(Storage[] storages, int maxLineCount)
+        public static string SummarizeStorageContents(Storage storage, int maxLineCount)
         {
             // Debug.Log($"[ContainerTooltips]: SummarizeStorageContents called for storage={storage?.name ?? "<null>"} maxLines={maxLines}");
 
-            if (storages == null)
+            if (storage == null)
             {
-                Debug.LogWarning("[ContainerTooltips]: Skipping null Storages");
+                Debug.LogWarning("[ContainerTooltips]: Skipping null Storage");
                 return string.Empty;
             }
 
-            var items = storages.SelectMany(storage => storage.items).ToList();
+            var items = storage.items;
             if (items == null || items.Count == 0)
             {
                 // Debug.Log("[ContainerTooltips]: SummarizeStorageContents found no items in storage(s)");


### PR DESCRIPTION
## Summary
- port the event-driven storage contents behaviour so tooltips refresh on GameHashes.OnStorageChange and invalidate per-storage caches
- update the ContainerTooltips summarizer and cache helpers to operate on a single Storage instance and expose cache invalidation hooks
- document the pending in-game validation step in NOTES.md so maintainers know to verify the refreshed tooltips manually

## Testing
- Manual in-game verification (not run: ONI runtime unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e616fa24908329b27a0642a8cce2db