### PR TITLE
Align ContainerTooltips string fallbacks

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -456,3 +456,9 @@ es the visibility compiler error.
 ## 2025-12-23 - DevLoader static content preload
 - Captured each mod DLL's root and added a reflection-based `KMod.Content` loader so static assets (strings, anims, templates) register before `OnLoad` executes.
 - Attempted to verify with `dotnet build src/DevLoader/DevLoader.csproj`, but the container still lacks the `.NET` host (`dotnet: command not found`). Please rebuild locally to ensure the helper compiles alongside the new preload workflow.
+## 2025-12-24 - ContainerTooltips localization fallback helpers
+- Added fallback-aware string registration to the legacy `ContainerTooltips` build so translations missing localized entries ret
+  urn the English `LocString` text like the maintained version.
+- Unable to validate in-game localization because the container cannot launch Oxygen Not Included; please load the mod with an a
+lternate language locally to confirm the fallback strings resolve correctly.
+


### PR DESCRIPTION
## Summary
- register ContainerTooltips status item strings via the LocString-aware helper so missing translations fall back to English
- add the maintained GetStringWithFallback, GetLocStringText, and RegisterString helpers to the legacy UserMod implementation
- update the shared notes to document the change and request manual localization validation

## Testing
- not run (Oxygen Not Included is unavailable in the container environment)


------
https://chatgpt.com/codex/tasks/task_e_68e618cf5c148329bc9cc2e619bd0cf1