### PR TITLE
Add MIT license to identifier bundle

### DIFF
--- a/Oni_mods_by_Identifier/LICENSE
+++ b/Oni_mods_by_Identifier/LICENSE
@@ -1,0 +1,26 @@
+MIT License
+
+Copyright (c) 2019 Aze
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+
+Some mods in this repo make use of Peter Han's PLib under MIT licensing.
+https://github.com/peterhaneve/ONIMods/blob/master/LICENSE

--- a/Oni_mods_by_Identifier/README.md
+++ b/Oni_mods_by_Identifier/README.md
@@ -33,3 +33,6 @@ Before distributing an archival build:
 - If new dependencies are required, document the source and expected filename in this section so future maintainers know how to repopulate their local `lib/` folder.
 
 By following these steps, the identifier-based archive stays consistent with the actively maintained mods while remaining ready for historical reference.
+
+## License
+The contents of this archive are distributed under the MIT License. See [`LICENSE`](./LICENSE) for the full terms, including the notice covering Peter Han's PLib dependency.


### PR DESCRIPTION
## Summary
- copy the repository MIT license into the Oni_mods_by_Identifier bundle so it carries the PLib notice
- document the license in the identifier bundle README for easy discovery

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e62356b0b0832997ae8346fb5ea99a