### PR TITLE
Update translation readmes with Identifier contact info

### DIFF
--- a/Oni_mods_by_Identifier/ContainerTooltips/Translations/README.md
+++ b/Oni_mods_by_Identifier/ContainerTooltips/Translations/README.md
@@ -60,10 +60,10 @@ Please test your translations to make sure everything works as intended before s
 
 ## Uploading
 *Thank you for your help!*  
-For your translation to be added, I will need the `.po` file. There are several ways you can get this file to me:
-- Create a new issue on this repository (preferred).
-- Create a PR.
-- Contact me on Discord (Aze#0066).
+For your translation to be added, I will need the `.po` file. There are several ways you can share this file with the Identifier maintainers:
+- [Open an issue](https://github.com/Identifier/ONIMods/issues) on the Identifier ONI Mods repository (preferred).
+- [Submit a pull request](https://github.com/Identifier/ONIMods/pulls) with your translation.
+- Reach out through the contact details listed in the repository's README if you need direct assistance.
 - Link it in Steam Workshop comments.
   
 #### Downloading from Github:

--- a/Translations/README.md
+++ b/Translations/README.md
@@ -60,10 +60,10 @@ Please test your translations to make sure everything works as intended before s
 
 ## Uploading
 *Thank you for your help!*  
-For your translation to be added, I will need the `.po` file. There are several ways you can get this file to me:
-- Create a new issue on this repository (preferred).
-- Create a PR.
-- Contact me on Discord (Aze#0066).
+For your translation to be added, I will need the `.po` file. There are several ways you can share this file with the Identifier maintainers:
+- [Open an issue](https://github.com/Identifier/ONIMods/issues) on the Identifier ONI Mods repository (preferred).
+- [Submit a pull request](https://github.com/Identifier/ONIMods/pulls) with your translation.
+- Reach out through the contact details listed in the repository's README if you need direct assistance.
 - Link it in Steam Workshop comments.
   
 #### Downloading from Github:


### PR DESCRIPTION
## Summary
- replace the Discord contact reference with Identifier ONI Mods repository links in the shared translation README files
- direct translators to the current Identifier maintainer contact details for further assistance

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e6251dd2148329b528b83a37a857ab