### PR TITLE
Add missing imports for ContainerTooltips Db Initialize patch

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -466,3 +466,7 @@ lternate language locally to confirm the fallback strings resolve correctly.
 ## 2025-12-25 - ContainerTooltips STRINGS archive sync
 - Bundled the `Mod/STRINGS.cs` scaffold inside `Oni_mods_by_Identifier/ContainerTooltips` so the legacy project matches the maintained repository's `global::STRINGS` constants without requiring a manual copy.
 - Attempted `dotnet build Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj` to confirm the SDK project automatically includes the new file, but the container still lacks the `.NET` host (`command not found: dotnet`). Please rerun the build locally to verify.
+
+## 2025-12-26 - ContainerTooltips Db.Initialize postfix imports
+- Added the missing `Database` and `UnityEngine` namespace imports to the legacy `Db.Initialize` postfix so the compiler resolves `Db` and `Debug` without relying on transitive usings.
+- Tried to rebuild with `dotnet build Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj`, but the container still lacks the `.NET` host (`command not found: dotnet`). Please rerun the build locally to confirm the patch compiles.

--- a/Oni_mods_by_Identifier/ContainerTooltips/Patches/Db/Initialize.cs
+++ b/Oni_mods_by_Identifier/ContainerTooltips/Patches/Db/Initialize.cs
@@ -1,4 +1,6 @@
+using Database;
 using HarmonyLib;
+using UnityEngine;
 
 namespace ContainerTooltips
 {


### PR DESCRIPTION
## Summary
- add explicit Database and UnityEngine imports to the legacy ContainerTooltips Db.Initialize postfix so Db and Debug resolve
- log the change and note the container build limitation in NOTES.md for follow-up maintainers

## Testing
- `dotnet build Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj` *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e6282830e083298197d5e79c26f405