### PR TITLE
Sync ContainerTooltips storage summarizer with upstream

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -470,3 +470,8 @@ lternate language locally to confirm the fallback strings resolve correctly.
 ## 2025-12-26 - ContainerTooltips Db.Initialize postfix imports
 - Added the missing `Database` and `UnityEngine` namespace imports to the legacy `Db.Initialize` postfix so the compiler resolves `Db` and `Debug` without relying on transitive usings.
 - Tried to rebuild with `dotnet build Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj`, but the container still lacks the `.NET` host (`command not found: dotnet`). Please rerun the build locally to confirm the patch compiles.
+
+## 2025-12-27 - ContainerTooltips storage summarizer sync
+- Replaced the legacy `StorageContentsSummarizer` with the maintained implementation so multi-line summaries match upstream behaviour while keeping the newline guard and explicit `GameUtil` formatting parameters.
+- Attempted `dotnet build Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj` to confirm the API alignment, but the container still lacks the `.NET` host (`command not found: dotnet`). Please rebuild locally to verify.
+- Unable to spot-check tooltips in-game because Oxygen Not Included is not available in the container; please confirm multi-line summaries render identically on a workstation with the game installed.

--- a/Oni_mods_by_Identifier/ContainerTooltips/StorageContentsSummarizer.cs
+++ b/Oni_mods_by_Identifier/ContainerTooltips/StorageContentsSummarizer.cs
@@ -2,16 +2,231 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Database;
+using Klei;
+using Klei.AI;
 using UnityEngine;
 
 namespace ContainerTooltips
 {
-    public static class StorageContentsSummarizer
+    internal static class StorageContentsSummarizer
     {
-        public static string SummarizeStorageContents(Storage storage, int maxLineCount)
+        private sealed class ContentSummary
         {
-            // Debug.Log($"[ContainerTooltips]: SummarizeStorageContents called for storage={storage?.name ?? "<null>"} maxLines={maxLines}");
+            private Dictionary<byte, int>? diseases;
+            private ContentSummaryCollection? children;
 
+            internal ContentSummary(string name, Tag tag, int depth)
+            {
+                Name = name;
+                Tag = tag;
+                Depth = depth;
+            }
+
+            internal string Name { get; }
+
+            internal Tag Tag { get; }
+
+            internal int Depth { get; }
+
+            internal int Count { get; set; }
+
+            internal float Mass { get; set; }
+
+            internal float Units { get; set; }
+
+            internal float Calories { get; set; }
+
+            internal float TemperatureSum { get; set; }
+
+            internal int TemperatureSamples { get; set; }
+
+            internal int TotalDiseaseCount { get; private set; }
+
+            internal IReadOnlyDictionary<byte, int>? Diseases => diseases;
+
+            internal ContentSummaryCollection? Children => children;
+
+            internal ContentSummaryCollection EnsureChildren()
+            {
+                return children ??= new ContentSummaryCollection(Depth + 1);
+            }
+
+            internal Dictionary<byte, int> EnsureDiseases()
+            {
+                return diseases ??= new Dictionary<byte, int>();
+            }
+
+            internal void AddDisease(byte diseaseIdx, int amount)
+            {
+                var values = EnsureDiseases();
+                values.TryGetValue(diseaseIdx, out var existing);
+                values[diseaseIdx] = existing + amount;
+                TotalDiseaseCount += amount;
+            }
+
+            public override string ToString()
+            {
+                var builder = new StringBuilder();
+                AppendTo(builder, this, 0);
+                return builder.ToString();
+            }
+
+            private static void AppendTo(StringBuilder builder, ContentSummary summary, int indentLevel)
+            {
+                var indent = new string(' ', indentLevel * 2);
+                builder.Append(indent).Append("ContentSummary {");
+                builder.Append(" Name=\"").Append(summary.Name).Append('\"');
+                builder.Append(", Tag=").Append(summary.Tag);
+                builder.Append(", Depth=").Append(summary.Depth);
+                builder.Append(", Count=").Append(summary.Count);
+                builder.Append(", Mass=").Append(summary.Mass);
+                builder.Append(", Units=").Append(summary.Units);
+                builder.Append(", Calories=").Append(summary.Calories);
+                builder.Append(", TemperatureSum=").Append(summary.TemperatureSum);
+                builder.Append(", TemperatureSamples=").Append(summary.TemperatureSamples);
+                builder.Append(", TotalDiseaseCount=").Append(summary.TotalDiseaseCount);
+                builder.Append(", Diseases=");
+
+                if (summary.diseases == null || summary.diseases.Count == 0)
+                {
+                    builder.Append("[]");
+                }
+                else
+                {
+                    builder.Append('[');
+                    var first = true;
+                    foreach (var disease in summary.diseases)
+                    {
+                        if (!first)
+                            builder.Append(", ");
+
+                        builder.Append(disease.Key).Append(':').Append(disease.Value);
+                        first = false;
+                    }
+
+                    builder.Append(']');
+                }
+
+                builder.Append(", Children=");
+                if (summary.children == null || summary.children.Count == 0)
+                {
+                    builder.Append("[]");
+                }
+                else
+                {
+                    builder.AppendLine("[");
+                    var items = summary.children.Items;
+                    for (var i = 0; i < items.Count; i++)
+                    {
+                        AppendTo(builder, items[i], indentLevel + 1);
+                        builder.AppendLine(i < items.Count - 1 ? "," : string.Empty);
+                    }
+
+                    builder.Append(indent).Append(']');
+                }
+
+                builder.Append(" }");
+            }
+        }
+
+        private sealed class ContentSummaryCollection
+        {
+            private readonly int depth;
+            private readonly Dictionary<Tag, ContentSummary> lookup = new();
+            private readonly List<ContentSummary> items = new();
+
+            internal ContentSummaryCollection(int depth)
+            {
+                this.depth = depth;
+            }
+
+            internal IReadOnlyList<ContentSummary> Items => items;
+
+            internal int Count => items.Count;
+
+            internal int Depth => depth;
+
+            internal ContentSummary GetOrAdd(Tag tag, string name)
+            {
+                if (!lookup.TryGetValue(tag, out var summary))
+                {
+                    summary = new ContentSummary(name, tag, depth);
+                    lookup.Add(tag, summary);
+                    items.Add(summary);
+                }
+
+                return summary;
+            }
+
+            internal void Sort(ContentSortMode sortMode)
+            {
+                if (sortMode == ContentSortMode.Default)
+                    return;
+
+                items.Sort(new ContentSummaryComparer(sortMode));
+                foreach (var item in items)
+                    item.Children?.Sort(sortMode);
+            }
+        }
+
+        private sealed class ContentSummaryComparer : IComparer<ContentSummary>
+        {
+            private readonly ContentSortMode mode;
+
+            internal ContentSummaryComparer(ContentSortMode mode)
+            {
+                this.mode = mode;
+            }
+
+            public int Compare(ContentSummary? x, ContentSummary? y)
+            {
+                if (ReferenceEquals(x, y))
+                    return 0;
+                if (x is null)
+                    return -1;
+                if (y is null)
+                    return 1;
+
+                return mode switch
+                {
+                    ContentSortMode.Alphabetical => CompareAlphabetical(x, y),
+                    ContentSortMode.Amount => CompareAmount(x, y),
+                    _ => 0
+                };
+            }
+
+            private static int CompareAlphabetical(ContentSummary x, ContentSummary y)
+            {
+                var value = string.Compare(x.Name, y.Name, StringComparison.CurrentCultureIgnoreCase);
+                return value == 0 ? CompareAmount(x, y) : value;
+            }
+
+            private static int CompareAmount(ContentSummary x, ContentSummary y)
+            {
+                var value = y.Mass.CompareTo(x.Mass);
+                if (value != 0)
+                    return value;
+
+                value = y.Calories.CompareTo(x.Calories);
+                if (value != 0)
+                    return value;
+
+                value = y.Units.CompareTo(x.Units);
+                if (value != 0)
+                    return value;
+
+                value = y.Count.CompareTo(x.Count);
+                return value == 0
+                    ? string.Compare(x.Name, y.Name, StringComparison.CurrentCultureIgnoreCase)
+                    : value;
+            }
+        }
+
+        private static bool loggedInvalidDiseaseIndex;
+
+        internal static string SummarizeStorageContents(Storage storage, int maxLines)
+        {
             if (storage == null)
             {
                 Debug.LogWarning("[ContainerTooltips]: Skipping null Storage");
@@ -20,72 +235,69 @@ namespace ContainerTooltips
 
             var items = storage.items;
             if (items == null || items.Count == 0)
-            {
-                // Debug.Log("[ContainerTooltips]: SummarizeStorageContents found no items in storage(s)");
                 return string.Empty;
-            }
 
-            var contentSummaries = new ContentSummaryCollection(0);
+            var summaries = new ContentSummaryCollection(0);
             var recursionGuard = new HashSet<int>();
-            foreach (var item in items)
-            {
-                ProcessStorageItem(item, contentSummaries, recursionGuard);
-            }
 
-            if (contentSummaries.Count == 0)
+            foreach (var item in items)
+                ProcessStorageItem(item, summaries, recursionGuard);
+
+            if (summaries.Count == 0)
             {
-                Debug.LogWarning("[ContainerTooltips]: SummarizeStorageContents created no summaries after processing items");
+                Debug.LogWarning($"[ContainerTooltips]: BuildContentsSummary created no summaries after processing items for {storage.name}");
                 return string.Empty;
             }
 
             var options = Options.Instance;
-            contentSummaries.Sort(options.SortMode);
+            summaries.Sort(options.SortMode);
 
-            var flattened = FlattenedSummaries(contentSummaries).ToList();
+            var flattened = FlattenedSummaries(summaries).ToList();
             if (flattened.Count == 0)
-            {
                 return string.Empty;
-            }
 
-            var sb = new StringBuilder(flattened.Count * 100);
-            var lineIndex = 0;
-            foreach (var summary in FlattenedSummaries(contentSummaries))
+            var limit = Mathf.Max(1, maxLines);
+            var builder = new StringBuilder(flattened.Count * 100);
+            var written = 0;
+
+            foreach (var entry in flattened)
             {
-                if (!(summary.Units > 0 || summary.Calories > 0 || summary.Diseases?.Count > 0 || summary.Children?.Count > 0))
+                if (!(entry.Units > 0f) && !(entry.Calories > 0f))
                 {
-                    Debug.Log($"[ContainerTooltips]: SummarizeStorageContents skipping content summary for {summary.Name} due to no substantial information.");
-                    continue;
+                    var diseases = entry.Diseases;
+                    if (diseases == null || diseases.Count == 0)
+                    {
+                        var children = entry.Children;
+                        if (children == null || children.Count == 0)
+                        {
+                            Debug.Log($"[ContainerTooltips]: Skipping content summary for {storage.name}'s {entry.Name} due to no substantial information.");
+                            continue;
+                        }
+                    }
                 }
 
-                if (lineIndex > 0)
-                {
-                    sb.Append('\n');
-                }
+                if (written > 0)
+                    builder.Append('\n');
 
-                sb.Append(FormatContentSummary(summary, options));
+                builder.Append(FormatContentSummary(entry, options));
+                written++;
 
-                lineIndex++;
-                if (lineIndex >= maxLineCount)
-                {
+                if (written >= limit)
                     break;
-                }
             }
 
-            if (flattened.Count > maxLineCount)
+            if (flattened.Count > limit)
             {
-                sb.Append('\n');
-                sb.Append('+');
-                sb.Append(flattened.Count - maxLineCount);
-                sb.Append(" more...");
+                builder.Append('\n');
+                builder.Append('+').Append(flattened.Count - limit).Append(" more...");
             }
 
-            return sb.ToString();
+            var summary = builder.ToString();
+            return written > 1 ? "\n" + summary : summary;
         }
 
-        private static void ProcessStorageItem(GameObject? item, ContentSummaryCollection contentSummaries, HashSet<int> recursionGuard)
+        private static void ProcessStorageItem(GameObject? item, ContentSummaryCollection summaries, HashSet<int> recursionGuard)
         {
-            // Debug.Log($"[ContainerTooltips]: Processing storage item {item?.name} at depth {contentSummaries.Depth}");
-
             if (item == null)
             {
                 Debug.LogWarning("[ContainerTooltips]: Skipping null GameObject");
@@ -101,27 +313,24 @@ namespace ContainerTooltips
 
             try
             {
-                var prefab = item.GetComponent<KPrefabID>();
-                if (prefab == null)
+                if (!item.TryGetComponent(out KPrefabID prefab))
                 {
                     Debug.LogWarning($"[ContainerTooltips]: GameObject {item.name} missing KPrefabID");
                     return;
                 }
 
-                var summary = contentSummaries.GetOrAdd(prefab.PrefabTag, prefab.GetProperName());
+                var summary = summaries.GetOrAdd(prefab.PrefabTag, prefab.GetProperName());
                 summary.Count++;
 
-                if (item.TryGetComponent(out PrimaryElement element))
+                if (item.TryGetComponent(out PrimaryElement primary))
                 {
-                    summary.Mass += element.Mass;
-                    summary.Units += element.Units;
-                    summary.TemperatureSum += element.Temperature;
+                    summary.Mass += primary.Mass;
+                    summary.Units += primary.Units;
+                    summary.TemperatureSum += primary.Temperature;
                     summary.TemperatureSamples++;
 
-                    if (element.DiseaseCount > 0)
-                    {
-                        summary.AddDisease(element.DiseaseIdx, element.DiseaseCount);
-                    }
+                    if (primary.DiseaseCount > 0)
+                        summary.AddDisease(primary.DiseaseIdx, primary.DiseaseCount);
                 }
                 else if (item.TryGetComponent(out Pickupable pickupable))
                 {
@@ -130,20 +339,14 @@ namespace ContainerTooltips
                 }
 
                 if (item.TryGetComponent(out Edible edible))
-                {
                     summary.Calories += edible.Calories;
-                }
 
-                if (item.TryGetComponent(out Storage nestedStorage) && nestedStorage.items != null && nestedStorage.items.Count > 0)
+                if (item.TryGetComponent(out Storage nested) && nested.items is { Count: > 0 })
                 {
                     var children = summary.EnsureChildren();
-                    foreach (var child in nestedStorage.items)
-                    {
-                        ProcessStorageItem(child, children, recursionGuard);
-                    }
+                    foreach (var nestedItem in nested.items)
+                        ProcessStorageItem(nestedItem, children, recursionGuard);
                 }
-
-                // Debug.Log($"[ContainerTooltips]: Processed storage item {summary}");
             }
             finally
             {
@@ -153,50 +356,51 @@ namespace ContainerTooltips
 
         private static string FormatContentSummary(ContentSummary summary, Options options)
         {
-            var appendItemCount = summary.Count > 1;
+            var hasMultiple = summary.Count > 1;
             string amount;
 
             if (summary.Mass > 0f)
             {
-                amount = GameUtil.GetFormattedMass(summary.Mass, massFormat: (GameUtil.MetricMassFormat)options.MassUnits);
+                amount = GameUtil.GetFormattedMass(
+                    summary.Mass,
+                    GameUtil.TimeSlice.None,
+                    (GameUtil.MetricMassFormat)options.MassUnits,
+                    includeSuffix: true,
+                    floatFormat: "{0:0.#}");
             }
             else if (summary.Units > 0f)
             {
-                amount = GameUtil.GetFormattedUnits(summary.Units);
+                amount = GameUtil.GetFormattedUnits(summary.Units, GameUtil.TimeSlice.None, true, string.Empty);
             }
             else
             {
                 Debug.Log($"[ContainerTooltips]: Item {summary} doesn't have any Mass or Units");
                 amount = $"{summary.Count} {(summary.Count == 1 ? "item" : "items")}";
-                appendItemCount = false;
+                hasMultiple = false;
             }
 
             if (summary.Calories > 0f)
-            {
-                amount += " (" + GameUtil.GetFormattedCalories(summary.Calories) + ")";
-            }
+                amount += " (" + GameUtil.GetFormattedCalories(summary.Calories, GameUtil.TimeSlice.None, true) + ")";
 
-            if (appendItemCount)
-            {
+            if (hasMultiple)
                 amount += $" ({summary.Count} {(summary.Count == 1 ? "item" : "items")})";
-            }
 
-            var temperatureSamples = summary.TemperatureSamples > 0 ? summary.TemperatureSamples : summary.Count;
-            var temperature = GameUtil.GetFormattedTemperature(summary.TemperatureSum / Mathf.Max(temperatureSamples, 1));
-            if (temperatureSamples > 1)
-            {
+            var samples = summary.TemperatureSamples > 0 ? summary.TemperatureSamples : summary.Count;
+            var temperature = GameUtil.GetFormattedTemperature(
+                summary.TemperatureSum / Mathf.Max(samples, 1),
+                GameUtil.TimeSlice.None,
+                GameUtil.TemperatureInterpretation.Absolute,
+                true);
+
+            if (samples > 1)
                 temperature = "~" + temperature;
-            }
 
-            var formatted = GetIndent(summary.Depth) + string.Format(options.LineFormat, summary.Name, amount, temperature);
+            var line = GetIndent(summary.Depth) + string.Format(options.LineFormat, summary.Name, amount, temperature);
+            var diseases = FormatDiseases(summary);
+            if (!string.IsNullOrEmpty(diseases))
+                line += "\n" + GetIndent(summary.Depth + 1) + diseases;
 
-            var germInfo = FormatDiseases(summary);
-            if (!string.IsNullOrEmpty(germInfo))
-            {
-                formatted += "\n" + GetIndent(summary.Depth + 1) + germInfo;
-            }
-
-            return formatted;
+            return line;
         }
 
         private static string GetIndent(int depth)
@@ -207,25 +411,35 @@ namespace ContainerTooltips
         private static string FormatDiseases(ContentSummary summary)
         {
             if (summary.TotalDiseaseCount <= 0 || summary.Diseases == null || summary.Diseases.Count == 0)
-            {
                 return string.Empty;
-            }
 
-            var totalText = GameUtil.GetFormattedDiseaseAmount(summary.TotalDiseaseCount);
-            var diseaseNames = string.Join(" + ", summary.Diseases.Select(d => SafeGetDiseaseName(d.Key)));
-            return $"{totalText} [{diseaseNames}]";
+            var diseaseDatabase = Db.Get().Diseases;
+            var diseaseCount = diseaseDatabase.Count;
+            var names = new List<string>();
 
-            static string SafeGetDiseaseName(byte diseaseId)
+            foreach (var kvp in summary.Diseases)
             {
-                try
+                var index = kvp.Key;
+                if (index == byte.MaxValue || index < 0 || index >= diseaseCount)
                 {
-                    return GameUtil.GetFormattedDiseaseName(diseaseId);
+                    if (!loggedInvalidDiseaseIndex)
+                    {
+                        Debug.LogWarning($"[ContainerTooltips]: Skipping invalid disease index {index} while summarizing storage contents");
+                        loggedInvalidDiseaseIndex = true;
+                    }
+
+                    continue;
                 }
-                catch
-                {
-                    return $"0x{diseaseId:X2}";
-                }
+
+                names.Add(GameUtil.GetFormattedDiseaseName(index, false));
             }
+
+            if (names.Count == 0)
+                return string.Empty;
+
+            var amount = GameUtil.GetFormattedDiseaseAmount(summary.TotalDiseaseCount, GameUtil.TimeSlice.None);
+            var diseaseList = string.Join(" + ", names);
+            return amount + " [" + diseaseList + "]";
         }
 
         private static IEnumerable<ContentSummary> FlattenedSummaries(ContentSummaryCollection entries)
@@ -233,237 +447,12 @@ namespace ContainerTooltips
             foreach (var item in entries.Items)
             {
                 yield return item;
-                if (item.Children != null)
-                {
-                    foreach (var nested in FlattenedSummaries(item.Children))
-                    {
-                        yield return nested;
-                    }
-                }
-            }
-        }
 
-        private sealed class ContentSummary
-        {
-            public ContentSummary(string name, Tag tag, int depth)
-            {
-                Name = name;
-                Tag = tag;
-                Depth = depth;
-            }
+                if (item.Children == null)
+                    continue;
 
-            public string Name { get; }
-            public Tag Tag { get; }
-            public int Depth { get; }
-            public int Count { get; set; }
-            public float Mass { get; set; }
-            public float Units { get; set; }
-            public float Calories { get; set; }
-            public float TemperatureSum { get; set; }
-            public int TemperatureSamples { get; set; }
-            public int TotalDiseaseCount { get; private set; }
-            public Dictionary<byte, int>? Diseases { get; private set; }
-            public ContentSummaryCollection? Children { get; private set; }
-
-            public ContentSummaryCollection EnsureChildren()
-            {
-                return Children ??= new(Depth + 1);
-            }
-
-            public Dictionary<byte, int> EnsureDiseases()
-            {
-                return Diseases ??= [];
-            }
-
-            public void AddDisease(byte diseaseIdx, int amount)
-            {
-                var diseases = EnsureDiseases();
-                diseases.TryGetValue(diseaseIdx, out var existing);
-                diseases[diseaseIdx] = existing + amount;
-
-                TotalDiseaseCount += amount;
-            }
-
-            public override string ToString()
-            {
-                var sb = new StringBuilder();
-                AppendTo(sb, this, 0);
-                return sb.ToString();
-
-                static void AppendTo(StringBuilder builder, ContentSummary summary, int indentLevel)
-                {
-                    var indent = new string(' ', indentLevel * 2);
-                    builder.Append(indent);
-                    builder.Append("ContentSummary {");
-                    builder.Append(" Name=").Append('"').Append(summary.Name).Append('"');
-                    builder.Append(", Tag=").Append(summary.Tag);
-                    builder.Append(", Depth=").Append(summary.Depth);
-                    builder.Append(", Count=").Append(summary.Count);
-                    builder.Append(", Mass=").Append(summary.Mass);
-                    builder.Append(", Units=").Append(summary.Units);
-                    builder.Append(", Calories=").Append(summary.Calories);
-                    builder.Append(", TemperatureSum=").Append(summary.TemperatureSum);
-                    builder.Append(", TemperatureSamples=").Append(summary.TemperatureSamples);
-                    builder.Append(", TotalDiseaseCount=").Append(summary.TotalDiseaseCount);
-                    builder.Append(", Diseases=");
-
-                    if (summary.Diseases == null || summary.Diseases.Count == 0)
-                    {
-                        builder.Append("[]");
-                    }
-                    else
-                    {
-                        builder.Append('[');
-                        var first = true;
-                        foreach (var kvp in summary.Diseases)
-                        {
-                            if (!first)
-                            {
-                                builder.Append(", ");
-                            }
-
-                            builder.Append(kvp.Key);
-                            builder.Append(':');
-                            builder.Append(kvp.Value);
-                            first = false;
-                        }
-
-                        builder.Append(']');
-                    }
-
-                    builder.Append(", Children=");
-                    if (summary.Children == null || summary.Children.Count == 0)
-                    {
-                        builder.Append("[]");
-                    }
-                    else
-                    {
-                        builder.AppendLine("[");
-                        var children = summary.Children.Items;
-                        for (var i = 0; i < children.Count; i++)
-                        {
-                            AppendTo(builder, children[i], indentLevel + 1);
-                            if (i < children.Count - 1)
-                            {
-                                builder.AppendLine(",");
-                            }
-                            else
-                            {
-                                builder.AppendLine();
-                            }
-                        }
-
-                        builder.Append(indent);
-                        builder.Append(']');
-                    }
-
-                    builder.Append(" }");
-                }
-            }
-        }
-
-        private sealed class ContentSummaryCollection
-        {
-            private readonly int depth;
-            private readonly Dictionary<Tag, ContentSummary> lookup = [];
-            private readonly List<ContentSummary> items = [];
-
-            public ContentSummaryCollection(int depth)
-            {
-                this.depth = depth;
-            }
-
-            public IReadOnlyList<ContentSummary> Items => items;
-            public int Count => items.Count;
-            public int Depth => depth;
-
-            public ContentSummary GetOrAdd(Tag tag, string name)
-            {
-                if (!lookup.TryGetValue(tag, out var summary))
-                {
-                    summary = new ContentSummary(name, tag, depth);
-                    lookup.Add(tag, summary);
-                    items.Add(summary);
-                }
-
-                return summary;
-            }
-
-            public void Sort(ContentSortMode sortMode)
-            {
-                if (sortMode != ContentSortMode.Default)
-                {
-                    items.Sort(new ContentSummaryComparer(sortMode));
-                    foreach (var item in items)
-                    {
-                        item.Children?.Sort(sortMode);
-                    }
-                }
-            }
-        }
-
-        private sealed class ContentSummaryComparer : IComparer<ContentSummary>
-        {
-            private readonly ContentSortMode mode;
-
-            public ContentSummaryComparer(ContentSortMode mode)
-            {
-                this.mode = mode;
-            }
-
-            public int Compare(ContentSummary? x, ContentSummary? y)
-            {
-                if (ReferenceEquals(x, y))
-                {
-                    return 0;
-                }
-
-                if (x is null)
-                {
-                    return -1;
-                }
-
-                if (y is null)
-                {
-                    return 1;
-                }
-
-                return mode switch
-                {
-                    ContentSortMode.Alphabetical => CompareAlphabetical(x, y),
-                    ContentSortMode.Amount => CompareAmount(x, y),
-                    _ => 0
-                };
-            }
-
-            private static int CompareAlphabetical(ContentSummary x, ContentSummary y)
-            {
-                var result = string.Compare(x.Name, y.Name, StringComparison.CurrentCultureIgnoreCase);
-                return result != 0 ? result : CompareAmount(x, y);
-            }
-
-            private static int CompareAmount(ContentSummary x, ContentSummary y)
-            {
-                var result = y.Mass.CompareTo(x.Mass);
-                if (result != 0)
-                {
-                    return result;
-                }
-
-                result = y.Calories.CompareTo(x.Calories);
-                if (result != 0)
-                {
-                    return result;
-                }
-
-                result = y.Units.CompareTo(x.Units);
-                if (result != 0)
-                {
-                    return result;
-                }
-
-                result = y.Count.CompareTo(x.Count);
-                return result != 0 ? result : string.Compare(x.Name, y.Name, StringComparison.CurrentCultureIgnoreCase);
+                foreach (var child in FlattenedSummaries(item.Children))
+                    yield return child;
             }
         }
     }


### PR DESCRIPTION
## Summary
- replace the legacy ContainerTooltips storage summarizer with the maintained implementation while keeping the newline guard and explicit GameUtil formatting parameters
- document the upstream sync and required follow-up validation in NOTES.md

## Testing
- `dotnet build Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj` *(fails: dotnet: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e629b645a88329a975f23d36d5f4f3