### PR TITLE
Fix ContainerTooltips mass display enum casting

### DIFF
--- a/Oni_mods_by_Identifier/ContainerTooltips/Options.cs
+++ b/Oni_mods_by_Identifier/ContainerTooltips/Options.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using PeterHan.PLib.Options;
+using OniGameUtil = global::GameUtil;
 
 namespace ContainerTooltips
 {
@@ -13,10 +14,10 @@ namespace ContainerTooltips
 
     public enum MassDisplayMode
     {
-        Default = GameUtil.MetricMassFormat.UseThreshold,
-        Kilogram = GameUtil.MetricMassFormat.Kilogram,
-        Gram = GameUtil.MetricMassFormat.Gram,
-        Tonne = GameUtil.MetricMassFormat.Tonne
+        Default = (int)OniGameUtil.MetricMassFormat.UseThreshold,
+        Kilogram = (int)OniGameUtil.MetricMassFormat.Kilogram,
+        Gram = (int)OniGameUtil.MetricMassFormat.Gram,
+        Tonne = (int)OniGameUtil.MetricMassFormat.Tonne
     }
 
     [JsonObject(MemberSerialization.OptOut)]


### PR DESCRIPTION
## Summary
- alias GameUtil to ensure explicit reference within ContainerTooltips options
- cast MassDisplayMode enum members to the underlying GameUtil metric formats for compatibility

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e62d1d6c948329a7eafd4da468c8e5