### PR TITLE
Update Container Tooltips mod info label

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -475,3 +475,7 @@ lternate language locally to confirm the fallback strings resolve correctly.
 - Replaced the legacy `StorageContentsSummarizer` with the maintained implementation so multi-line summaries match upstream behaviour while keeping the newline guard and explicit `GameUtil` formatting parameters.
 - Attempted `dotnet build Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj` to confirm the API alignment, but the container still lacks the `.NET` host (`command not found: dotnet`). Please rebuild locally to verify.
 - Unable to spot-check tooltips in-game because Oxygen Not Included is not available in the container; please confirm multi-line summaries render identically on a workstation with the game installed.
+
+## 2025-12-28 - ContainerTooltips mod metadata label update
+- Swapped the options dialog `[ModInfo]` attribute to use the human-readable mod name so the UI surfaces "Container Tooltips" instead of the repository URL.
+- Attempted `dotnet build Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj` to validate the metadata change but the container still lacks the `.NET` host (`command not found: dotnet`). Please rebuild locally and confirm the options screen reflects the new title.

--- a/Oni_mods_by_Identifier/ContainerTooltips/Options.cs
+++ b/Oni_mods_by_Identifier/ContainerTooltips/Options.cs
@@ -21,7 +21,7 @@ namespace ContainerTooltips
     }
 
     [JsonObject(MemberSerialization.OptOut)]
-    [ModInfo("https://github.com/Identifier/ONIMods")]
+    [ModInfo("Container Tooltips")]
     public sealed class Options : SingletonOptions<Options>, IOptions
     {
         [Option("Sort Order", "Controls how container contents are ordered in the displayed list.")]


### PR DESCRIPTION
## Summary
- update the Container Tooltips options metadata to display the mod name instead of the repository URL
- document the change and the blocked local build in NOTES.md

## Testing
- not run (dotnet CLI is unavailable in the container environment)

------
https://chatgpt.com/codex/tasks/task_e_68e62f8eaf4483298822110936275455