### PR TITLE
Add identifier Directory.Build.props bridge for property imports

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -479,3 +479,7 @@ lternate language locally to confirm the fallback strings resolve correctly.
 ## 2025-12-28 - ContainerTooltips mod metadata label update
 - Swapped the options dialog `[ModInfo]` attribute to use the human-readable mod name so the UI surfaces "Container Tooltips" instead of the repository URL.
 - Attempted `dotnet build Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj` to validate the metadata change but the container still lacks the `.NET` host (`command not found: dotnet`). Please rebuild locally and confirm the options screen reflects the new title.
+
+## 2025-12-29 - Identifier Directory.Build.props bridge
+- Added an identifier-level `Directory.Build.props` that defers to the shared `.default`/`.user` pair so legacy projects consume the same path overrides as the main solution.
+- Attempted to capture `$(GameFolder)` via `dotnet msbuild Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj /t:ResolveProjectReferences /v:diag`, but the container still lacks the `.NET` host (`command not found: dotnet`). Please re-run the diagnostic build locally to confirm the property evaluation.

--- a/Oni_mods_by_Identifier/Directory.Build.props
+++ b/Oni_mods_by_Identifier/Directory.Build.props
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <Import Project="Directory.Build.props.default" />
+  <Import Condition="Exists('Directory.Build.props.user')" Project="Directory.Build.props.user" />
+</Project>


### PR DESCRIPTION
## Summary
- add an identifier-level Directory.Build.props that forwards to the shared .default/.user property overrides
- document the missing dotnet host while attempting to collect msbuild diagnostics

## Testing
- `dotnet msbuild Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj /t:ResolveProjectReferences /v:diag` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e639ea17748329b5c21c4494a0edc3