### PR TITLE
Point identifier projects at game folder overrides

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -483,3 +483,7 @@ lternate language locally to confirm the fallback strings resolve correctly.
 ## 2025-12-29 - Identifier Directory.Build.props bridge
 - Added an identifier-level `Directory.Build.props` that defers to the shared `.default`/`.user` pair so legacy projects consume the same path overrides as the main solution.
 - Attempted to capture `$(GameFolder)` via `dotnet msbuild Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj /t:ResolveProjectReferences /v:diag`, but the container still lacks the `.NET` host (`command not found: dotnet`). Please re-run the diagnostic build locally to confirm the property evaluation.
+
+## 2025-12-30 - Identifier projects prefer live game assemblies
+- Updated the legacy `ContainerTooltips` and `ZoomSpeed` project references to read assemblies from `$(GameFolder)` with a fallback to the optional `lib/` cache so they align with the standard `Directory.Build.props.user` override.
+- Tried to validate with `dotnet build Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj`, but the container still lacks the `.NET` host (`command not found: dotnet`). Please rerun the build locally to confirm the live game folder resolves successfully.

--- a/Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj
+++ b/Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj
@@ -12,22 +12,28 @@
 
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>../lib/0Harmony.dll</HintPath>
+      <HintPath Condition="Exists('$(GameFolder)/0Harmony.dll')">$(GameFolder)/0Harmony.dll</HintPath>
+      <HintPath Condition="!Exists('$(GameFolder)/0Harmony.dll')">../lib/0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp">
-      <HintPath>../lib/Assembly-CSharp.dll</HintPath>
+      <HintPath Condition="Exists('$(GameFolder)/Assembly-CSharp.dll')">$(GameFolder)/Assembly-CSharp.dll</HintPath>
+      <HintPath Condition="!Exists('$(GameFolder)/Assembly-CSharp.dll')">../lib/Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp-firstpass">
-      <HintPath>../lib/Assembly-CSharp-firstpass.dll</HintPath>
+      <HintPath Condition="Exists('$(GameFolder)/Assembly-CSharp-firstpass.dll')">$(GameFolder)/Assembly-CSharp-firstpass.dll</HintPath>
+      <HintPath Condition="!Exists('$(GameFolder)/Assembly-CSharp-firstpass.dll')">../lib/Assembly-CSharp-firstpass.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine">
-      <HintPath>../lib/UnityEngine.dll</HintPath>
+      <HintPath Condition="Exists('$(GameFolder)/UnityEngine.dll')">$(GameFolder)/UnityEngine.dll</HintPath>
+      <HintPath Condition="!Exists('$(GameFolder)/UnityEngine.dll')">../lib/UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>../lib/UnityEngine.CoreModule.dll</HintPath>
+      <HintPath Condition="Exists('$(GameFolder)/UnityEngine.CoreModule.dll')">$(GameFolder)/UnityEngine.CoreModule.dll</HintPath>
+      <HintPath Condition="!Exists('$(GameFolder)/UnityEngine.CoreModule.dll')">../lib/UnityEngine.CoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI">
-      <HintPath>../lib/UnityEngine.UI.dll</HintPath>
+      <HintPath Condition="Exists('$(GameFolder)/UnityEngine.UI.dll')">$(GameFolder)/UnityEngine.UI.dll</HintPath>
+      <HintPath Condition="!Exists('$(GameFolder)/UnityEngine.UI.dll')">../lib/UnityEngine.UI.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/Oni_mods_by_Identifier/README.md
+++ b/Oni_mods_by_Identifier/README.md
@@ -43,7 +43,7 @@ Adjust the values to match your workstation, then rebuild so the shared targets 
 
 ## Handling Local Libraries
 - The historic packages assumed a `lib/` folder populated with Harmony, PLib, and Unity assemblies extracted from a local ONI installation. These binaries are no longer tracked in source control to avoid redistributing game files.
-- You can either populate `Oni_mods_by_Identifier/lib/` with the required DLLs **or** rely on `Directory.Build.props.user` to point directly at your ONI install so MSBuild references the live binaries without copying them. Choose the workflow that best fits your environment.
+- You can either populate `Oni_mods_by_Identifier/lib/` with the required DLLs **or** rely on `Directory.Build.props.user` to point directly at your ONI install so MSBuild references the live binaries without copying them. Choose the workflow that best fits your environment. The bundled `ContainerTooltips.csproj` and `ZoomSpeed.csproj` now honor the `$(GameFolder)` override automatically, falling back to the optional `lib/` cache only when the live game assemblies are unavailable.
 - If new dependencies are required, document the source and expected filename in this section so future maintainers know how to repopulate their local `lib/` folder (or update their `.user` overrides accordingly).
 
 By following these steps, the identifier-based archive stays consistent with the actively maintained mods while remaining ready for historical reference.

--- a/Oni_mods_by_Identifier/ZoomSpeed/ZoomSpeed.csproj
+++ b/Oni_mods_by_Identifier/ZoomSpeed/ZoomSpeed.csproj
@@ -12,25 +12,32 @@
 
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>../lib/0Harmony.dll</HintPath>
+      <HintPath Condition="Exists('$(GameFolder)/0Harmony.dll')">$(GameFolder)/0Harmony.dll</HintPath>
+      <HintPath Condition="!Exists('$(GameFolder)/0Harmony.dll')">../lib/0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp">
-      <HintPath>../lib/Assembly-CSharp.dll</HintPath>
+      <HintPath Condition="Exists('$(GameFolder)/Assembly-CSharp.dll')">$(GameFolder)/Assembly-CSharp.dll</HintPath>
+      <HintPath Condition="!Exists('$(GameFolder)/Assembly-CSharp.dll')">../lib/Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp-firstpass">
-      <HintPath>../lib/Assembly-CSharp-firstpass.dll</HintPath>
+      <HintPath Condition="Exists('$(GameFolder)/Assembly-CSharp-firstpass.dll')">$(GameFolder)/Assembly-CSharp-firstpass.dll</HintPath>
+      <HintPath Condition="!Exists('$(GameFolder)/Assembly-CSharp-firstpass.dll')">../lib/Assembly-CSharp-firstpass.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine">
-      <HintPath>../lib/UnityEngine.dll</HintPath>
+      <HintPath Condition="Exists('$(GameFolder)/UnityEngine.dll')">$(GameFolder)/UnityEngine.dll</HintPath>
+      <HintPath Condition="!Exists('$(GameFolder)/UnityEngine.dll')">../lib/UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>../lib/UnityEngine.CoreModule.dll</HintPath>
+      <HintPath Condition="Exists('$(GameFolder)/UnityEngine.CoreModule.dll')">$(GameFolder)/UnityEngine.CoreModule.dll</HintPath>
+      <HintPath Condition="!Exists('$(GameFolder)/UnityEngine.CoreModule.dll')">../lib/UnityEngine.CoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI">
-      <HintPath>../lib/UnityEngine.UI.dll</HintPath>
+      <HintPath Condition="Exists('$(GameFolder)/UnityEngine.UI.dll')">$(GameFolder)/UnityEngine.UI.dll</HintPath>
+      <HintPath Condition="!Exists('$(GameFolder)/UnityEngine.UI.dll')">../lib/UnityEngine.UI.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.InputLegacyModule">
-      <HintPath>../lib/UnityEngine.InputLegacyModule.dll</HintPath>
+      <HintPath Condition="Exists('$(GameFolder)/UnityEngine.InputLegacyModule.dll')">$(GameFolder)/UnityEngine.InputLegacyModule.dll</HintPath>
+      <HintPath Condition="!Exists('$(GameFolder)/UnityEngine.InputLegacyModule.dll')">../lib/UnityEngine.InputLegacyModule.dll</HintPath>
     </Reference>
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- update the ContainerTooltips and ZoomSpeed project references to prefer $(GameFolder) assemblies with a lib/ fallback
- document in the identifier README that the csproj files honor Directory.Build.props.user when resolving dependencies
- log the change and the pending build verification in NOTES.md for follow-up

## Testing
- `dotnet build Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj` *(fails: dotnet host is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e63ace3d888329963846085076e41e