### PR TITLE
Inline identifier release packaging targets

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -4,6 +4,11 @@
 - Removed the hard-coded `Assembly-CSharp.dll` reference from `SuppressNotifications.csproj` so the project now inherits the `_public` assemblies through `Directory.Build.props`.
 - Attempted to rebuild with `dotnet build src/SuppressNotifications/SuppressNotifications.csproj` to confirm `Assets.CreatePrefabs` resolves under the shared references, but the container still lacks the `.NET` host (`command not found: dotnet`). Please rerun the build locally once the ONI toolchain is available to verify compilation succeeds.
 
+## 2025-12-31 - Identifier release packaging restore
+- Defaulted the legacy identifier mods' Release configuration to local `Release/<ModId>` and `Distribute/` folders within the identifier repo and enabled `DeployOniMod` automatically so packaging runs without extra MSBuild properties.
+- Inlined bespoke packaging targets for `ContainerTooltips` and `ZoomSpeed` to merge dependencies, rebuild the Release install folder, and zip the DLL alongside `mod.yaml` and `mod_info.yaml` without importing shared targets from the main solution.
+- Attempted `dotnet build Oni_mods_by_Identifier/ONIMods.sln -c Release` to verify the Release packaging flow, but the container still lacks the `.NET` host (`command not found: dotnet`). Please rebuild locally to confirm the artifacts populate `Release/` and `Distribute/` as expected.
+
 ## 2025-12-23 - SuppressNotifications copy tool override scope
 - Widened the override visibility for `CopyEntitySettingsTool`'s drag lifecycle hooks to `public` so they match `DragTool`'s declarations and clear the CS0507 accessibility mismatch.
 - Attempted to rebuild with `dotnet build src/SuppressNotifications/SuppressNotifications.csproj`, but the container still lacks the `.NET` host (`command not found: dotnet`). Please rerun the build locally once the ONI toolchain is available to confirm the access modifier adjustments compile without warnings.

--- a/Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj
+++ b/Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj
@@ -10,6 +10,13 @@
     <ModId>ContainerTooltips</ModId>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <InstallFolder Condition="'$(InstallFolder)' == ''">$(MSBuildThisFileDirectory)..\Release\$(ModId)</InstallFolder>
+    <DistributeFolder Condition="'$(DistributeFolder)' == ''">$(MSBuildThisFileDirectory)..\Distribute\</DistributeFolder>
+    <DeployOniMod Condition="'$(DeployOniMod)' == ''">true</DeployOniMod>
+    <ShouldDistribute Condition="'$(ShouldDistribute)' == ''">true</ShouldDistribute>
+  </PropertyGroup>
+
   <ItemGroup>
     <Reference Include="0Harmony">
       <HintPath Condition="Exists('$(GameFolder)/0Harmony.dll')">$(GameFolder)/0Harmony.dll</HintPath>
@@ -41,6 +48,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="PLib" Version="4.17.1" />
     <PackageReference Include="ILRepack.Lib.MSBuild.Task" Version="2.0.26" PrivateAssets="All" />
+    <PackageReference Include="MSBuildTasks" Version="1.5.0.235" PrivateAssets="All" />
   </ItemGroup>
 
   <!-- Cross-platform deploy to ONI Local mods folder via MSBuild -->
@@ -71,6 +79,28 @@
 
     <Move SourceFiles="$(MergedAssemblyPath)" DestinationFiles="$(TargetPath)" OverwriteReadOnlyFiles="true" />
     <Move SourceFiles="$(MergedPdbPath)" DestinationFiles="$(TargetDir)$(TargetName).pdb" Condition="Exists('$(MergedPdbPath)')" OverwriteReadOnlyFiles="true" />
+  </Target>
+
+  <Target Name="PrepareReleaseFolders" AfterTargets="MergeDependencies" Condition="'$(Configuration)' == 'Release' And '$(ShouldDistribute)' != 'false'">
+    <RemoveDir Directories="$(InstallFolder)" Condition="Exists('$(InstallFolder)')" />
+    <MakeDir Directories="$(InstallFolder)" />
+    <MakeDir Directories="$(DistributeFolder)" />
+  </Target>
+
+  <Target Name="CopyReleaseArtifacts" AfterTargets="PrepareReleaseFolders" Condition="'$(Configuration)' == 'Release' And '$(ShouldDistribute)' != 'false'">
+    <ItemGroup>
+      <ReleaseOutputs Include="$(TargetPath)" />
+      <ReleaseOutputs Include="$(ProjectDir)mod.yaml" />
+      <ReleaseOutputs Include="$(ProjectDir)mod_info.yaml" />
+    </ItemGroup>
+    <Copy SourceFiles="@(ReleaseOutputs)" DestinationFolder="$(InstallFolder)" />
+  </Target>
+
+  <Target Name="ZipRelease" AfterTargets="CopyReleaseArtifacts" Condition="'$(Configuration)' == 'Release' And '$(ShouldDistribute)' != 'false'">
+    <CreateItem Include="$(InstallFolder)\**\*.*" Exclude="$(InstallFolder)\*.zip">
+      <Output ItemName="ZipFiles" TaskParameter="Include" />
+    </CreateItem>
+    <Zip ZipFileName="$(DistributeFolder)\$(ModId).zip" WorkingDirectory="$(InstallFolder)" Files="@(ZipFiles)" Flatten="false" />
   </Target>
 
   <Target Name="DeployOniMod" AfterTargets="Build" DependsOnTargets="MergeDependencies" Condition="'$(DeployOniMod)' != ''">

--- a/Oni_mods_by_Identifier/ZoomSpeed/ZoomSpeed.csproj
+++ b/Oni_mods_by_Identifier/ZoomSpeed/ZoomSpeed.csproj
@@ -10,6 +10,13 @@
     <ModId>ZoomSpeed</ModId>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <InstallFolder Condition="'$(InstallFolder)' == ''">$(MSBuildThisFileDirectory)..\Release\$(ModId)</InstallFolder>
+    <DistributeFolder Condition="'$(DistributeFolder)' == ''">$(MSBuildThisFileDirectory)..\Distribute\</DistributeFolder>
+    <DeployOniMod Condition="'$(DeployOniMod)' == ''">true</DeployOniMod>
+    <ShouldDistribute Condition="'$(ShouldDistribute)' == ''">true</ShouldDistribute>
+  </PropertyGroup>
+
   <ItemGroup>
     <Reference Include="0Harmony">
       <HintPath Condition="Exists('$(GameFolder)/0Harmony.dll')">$(GameFolder)/0Harmony.dll</HintPath>
@@ -45,6 +52,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="PLib" Version="4.17.1" />
     <PackageReference Include="ILRepack.Lib.MSBuild.Task" Version="2.0.26" PrivateAssets="All" />
+    <PackageReference Include="MSBuildTasks" Version="1.5.0.235" PrivateAssets="All" />
   </ItemGroup>
 
   <!-- Cross-platform deploy to ONI Local mods folder via MSBuild -->
@@ -75,7 +83,29 @@
 
     <Move SourceFiles="$(MergedAssemblyPath)" DestinationFiles="$(TargetPath)" OverwriteReadOnlyFiles="true" />
     <Move SourceFiles="$(MergedPdbPath)" DestinationFiles="$(TargetDir)$(TargetName).pdb" Condition="Exists('$(MergedPdbPath)')" OverwriteReadOnlyFiles="true" />
-</Target>
+  </Target>
+
+  <Target Name="PrepareReleaseFolders" AfterTargets="MergeDependencies" Condition="'$(Configuration)' == 'Release' And '$(ShouldDistribute)' != 'false'">
+    <RemoveDir Directories="$(InstallFolder)" Condition="Exists('$(InstallFolder)')" />
+    <MakeDir Directories="$(InstallFolder)" />
+    <MakeDir Directories="$(DistributeFolder)" />
+  </Target>
+
+  <Target Name="CopyReleaseArtifacts" AfterTargets="PrepareReleaseFolders" Condition="'$(Configuration)' == 'Release' And '$(ShouldDistribute)' != 'false'">
+    <ItemGroup>
+      <ReleaseOutputs Include="$(TargetPath)" />
+      <ReleaseOutputs Include="$(ProjectDir)mod.yaml" />
+      <ReleaseOutputs Include="$(ProjectDir)mod_info.yaml" />
+    </ItemGroup>
+    <Copy SourceFiles="@(ReleaseOutputs)" DestinationFolder="$(InstallFolder)" />
+  </Target>
+
+  <Target Name="ZipRelease" AfterTargets="CopyReleaseArtifacts" Condition="'$(Configuration)' == 'Release' And '$(ShouldDistribute)' != 'false'">
+    <CreateItem Include="$(InstallFolder)\**\*.*" Exclude="$(InstallFolder)\*.zip">
+      <Output ItemName="ZipFiles" TaskParameter="Include" />
+    </CreateItem>
+    <Zip ZipFileName="$(DistributeFolder)\$(ModId).zip" WorkingDirectory="$(InstallFolder)" Files="@(ZipFiles)" Flatten="false" />
+  </Target>
 
   <Target Name="DeployOniMod" AfterTargets="Build" DependsOnTargets="MergeDependencies" Condition="'$(DeployOniMod)' != ''">
     <Message Text="Deploying mod to: $(OniLocalModsDir)" Importance="High" />


### PR DESCRIPTION
## Summary
- keep the identifier mods' Release outputs inside the standalone repository and enable DeployOniMod by default
- inline release packaging targets so ContainerTooltips and ZoomSpeed merge PLib, rebuild the install folder, and zip the metadata without importing shared targets
- document the release folder defaults and packaging verification gap for future maintainers

## Testing
- `dotnet build Oni_mods_by_Identifier/ONIMods.sln -c Release` *(fails: `dotnet` is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e640ff661c8329a19029472d2244e7