### PR TITLE
Update release packaging folders for identifier mods

### DIFF
--- a/Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj
+++ b/Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
-    <InstallFolder Condition="'$(InstallFolder)' == ''">$(MSBuildThisFileDirectory)..\Release\$(ModId)</InstallFolder>
-    <DistributeFolder Condition="'$(DistributeFolder)' == ''">$(MSBuildThisFileDirectory)..\Distribute\</DistributeFolder>
+    <InstallFolder Condition="'$(InstallFolder)' == ''">$(TargetDir)</InstallFolder>
+    <DistributeFolder Condition="'$(DistributeFolder)' == ''">$(MSBuildThisFileDirectory)..\Releases\</DistributeFolder>
     <DeployOniMod Condition="'$(DeployOniMod)' == ''">true</DeployOniMod>
     <ShouldDistribute Condition="'$(ShouldDistribute)' == ''">true</ShouldDistribute>
   </PropertyGroup>
@@ -82,8 +82,6 @@
   </Target>
 
   <Target Name="PrepareReleaseFolders" AfterTargets="MergeDependencies" Condition="'$(Configuration)' == 'Release' And '$(ShouldDistribute)' != 'false'">
-    <RemoveDir Directories="$(InstallFolder)" Condition="Exists('$(InstallFolder)')" />
-    <MakeDir Directories="$(InstallFolder)" />
     <MakeDir Directories="$(DistributeFolder)" />
   </Target>
 

--- a/Oni_mods_by_Identifier/ZoomSpeed/ZoomSpeed.csproj
+++ b/Oni_mods_by_Identifier/ZoomSpeed/ZoomSpeed.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
-    <InstallFolder Condition="'$(InstallFolder)' == ''">$(MSBuildThisFileDirectory)..\Release\$(ModId)</InstallFolder>
-    <DistributeFolder Condition="'$(DistributeFolder)' == ''">$(MSBuildThisFileDirectory)..\Distribute\</DistributeFolder>
+    <InstallFolder Condition="'$(InstallFolder)' == ''">$(TargetDir)</InstallFolder>
+    <DistributeFolder Condition="'$(DistributeFolder)' == ''">$(MSBuildThisFileDirectory)..\Releases\</DistributeFolder>
     <DeployOniMod Condition="'$(DeployOniMod)' == ''">true</DeployOniMod>
     <ShouldDistribute Condition="'$(ShouldDistribute)' == ''">true</ShouldDistribute>
   </PropertyGroup>
@@ -86,8 +86,6 @@
   </Target>
 
   <Target Name="PrepareReleaseFolders" AfterTargets="MergeDependencies" Condition="'$(Configuration)' == 'Release' And '$(ShouldDistribute)' != 'false'">
-    <RemoveDir Directories="$(InstallFolder)" Condition="Exists('$(InstallFolder)')" />
-    <MakeDir Directories="$(InstallFolder)" />
     <MakeDir Directories="$(DistributeFolder)" />
   </Target>
 


### PR DESCRIPTION
## Summary
- point ContainerTooltips and ZoomSpeed release install folder to the build output directory
- write release archives to the shared `Releases` directory without deleting the build output

## Testing
- not run (MSBuild packaging not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e64b5152908329a71afa49dbb61e6a