### PR TITLE
Ensure identifier mods copy metadata to build output

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -492,3 +492,7 @@ lternate language locally to confirm the fallback strings resolve correctly.
 ## 2025-12-30 - Identifier projects prefer live game assemblies
 - Updated the legacy `ContainerTooltips` and `ZoomSpeed` project references to read assemblies from `$(GameFolder)` with a fallback to the optional `lib/` cache so they align with the standard `Directory.Build.props.user` override.
 - Tried to validate with `dotnet build Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj`, but the container still lacks the `.NET` host (`command not found: dotnet`). Please rerun the build locally to confirm the live game folder resolves successfully.
+
+## 2025-12-31 - Identifier metadata copied to build output
+- Enabled `CopyToOutputDirectory="PreserveNewest"` for `mod.yaml`, `mod_info.yaml`, `preview.png`, and translation assets so debug and release builds include the static metadata next to the compiled assemblies.
+- Attempted to verify with `dotnet build Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj`, but the container still lacks the `.NET` host (`command not found: dotnet`). Please rebuild locally (Debug and Release) to confirm the YAML files land in `bin/<Configuration>/<TFM>/`.

--- a/Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj
+++ b/Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj
@@ -51,6 +51,21 @@
     <PackageReference Include="MSBuildTasks" Version="1.5.0.235" PrivateAssets="All" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="mod.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="mod_info.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="preview.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Translations\**\*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
   <!-- Cross-platform deploy to ONI Local mods folder via MSBuild -->
   <PropertyGroup>
     <!-- Allow override: dotnet build /p:OniLocalModsDir=... or env var -->

--- a/Oni_mods_by_Identifier/ZoomSpeed/ZoomSpeed.csproj
+++ b/Oni_mods_by_Identifier/ZoomSpeed/ZoomSpeed.csproj
@@ -55,6 +55,18 @@
     <PackageReference Include="MSBuildTasks" Version="1.5.0.235" PrivateAssets="All" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="mod.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="mod_info.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="preview.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
   <!-- Cross-platform deploy to ONI Local mods folder via MSBuild -->
   <PropertyGroup>
     <!-- Allow override: dotnet build /p:OniLocalModsDir=... or env var -->


### PR DESCRIPTION
## Summary
- ensure the ContainerTooltips project marks mod.yaml, mod_info.yaml, preview.png, and translation assets to copy into the build output
- ensure the ZoomSpeed project marks its mod metadata files to copy alongside the compiled assemblies
- document the blocked build verification in NOTES.md for follow-up

## Testing
- not run (dotnet CLI is unavailable in the container)

------
https://chatgpt.com/codex/tasks/task_e_68e64bf406648329939d82c964e0d1a9