### PR TITLE
Disable copy local for identifier references

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -496,3 +496,7 @@ lternate language locally to confirm the fallback strings resolve correctly.
 ## 2025-12-31 - Identifier metadata copied to build output
 - Enabled `CopyToOutputDirectory="PreserveNewest"` for `mod.yaml`, `mod_info.yaml`, `preview.png`, and translation assets so debug and release builds include the static metadata next to the compiled assemblies.
 - Attempted to verify with `dotnet build Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj`, but the container still lacks the `.NET` host (`command not found: dotnet`). Please rebuild locally (Debug and Release) to confirm the YAML files land in `bin/<Configuration>/<TFM>/`.
+
+## 2026-01-01 - Identifier reference copy-local disable
+- Set the identifier-level `Directory.Build.props.default` to mark `Reference`, `ProjectReference`, and `PackageReference` items as non-private so only the merged assemblies land in mod output folders.
+- Attempted `dotnet build Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj` to confirm ONI assemblies stay under `$(GameFolder)`, but the container still lacks the `.NET` host (`command not found: dotnet`). Please rerun the build locally to validate the copy-local behavior.

--- a/Oni_mods_by_Identifier/Directory.Build.props.default
+++ b/Oni_mods_by_Identifier/Directory.Build.props.default
@@ -6,4 +6,16 @@
     <GameFolder>$(SteamFolder)\steamapps\common\OxygenNotIncluded\OxygenNotIncluded_Data\Managed</GameFolder>
     <ModFolder>$(UserProfile)\Documents\Klei\OxygenNotIncluded\mods\dev</ModFolder>
   </PropertyGroup>
+
+  <ItemDefinitionGroup>
+    <Reference>
+      <Private>false</Private>
+    </Reference>
+    <ProjectReference>
+      <Private>false</Private>
+    </ProjectReference>
+    <PackageReference>
+      <Private>false</Private>
+    </PackageReference>
+  </ItemDefinitionGroup>
 </Project>


### PR DESCRIPTION
## Summary
- mark reference items as non-private in `Oni_mods_by_Identifier/Directory.Build.props.default` so legacy projects avoid copying ONI assemblies
- document the change and the outstanding local build validation in `NOTES.md`

## Testing
- `dotnet build Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj` *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e64e4ed8c08329b7b13ce6993e8650