### PR TITLE
Pin identifier archives to net471

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -500,3 +500,7 @@ lternate language locally to confirm the fallback strings resolve correctly.
 ## 2026-01-01 - Identifier reference copy-local disable
 - Set the identifier-level `Directory.Build.props.default` to mark `Reference`, `ProjectReference`, and `PackageReference` items as non-private so only the merged assemblies land in mod output folders.
 - Attempted `dotnet build Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj` to confirm ONI assemblies stay under `$(GameFolder)`, but the container still lacks the `.NET` host (`command not found: dotnet`). Please rerun the build locally to validate the copy-local behavior.
+
+## 2026-01-02 - Identifier TFMs pinned to net471
+- Downgraded the `ContainerTooltips` and `ZoomSpeed` archival projects to target `net471` so their merged assemblies match ONI's Harmony runtime.
+- Attempted `dotnet build Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj /p:Configuration=Release` to confirm the net471 build and ILRepack packaging, but the container still lacks the `.NET` host (`command not found: dotnet`). Please rebuild locally (Debug/Release) to verify the merged assembly and release zip succeed under the new TFM.

--- a/Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj
+++ b/Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net471</TargetFramework>
     <AssemblyName>ContainerTooltips</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>

--- a/Oni_mods_by_Identifier/README.md
+++ b/Oni_mods_by_Identifier/README.md
@@ -14,6 +14,8 @@ This directory captures legacy identifiers of Oxygen Not Included mods that were
 ## Rebuild Reference
 This archive is self-contained. Treat `ContainerTooltips.csproj` inside `Oni_mods_by_Identifier/ContainerTooltips` as the authoritative project file when rebuilding or validating the mod. Restore packages and build directly against this project, using the `Directory.Build.props.user` override documented below to point MSBuild at your local ONI install. The legacy `ONIMods.sln` remains only as historical context; do not rely on the `src/` solution or its build graph when working from this repository.
 
+> **Compatibility note:** All archival projects must stay on `net471` so the merged assemblies remain compatible with Oxygen Not Included's bundled Harmony runtime. Do not bump the TFM without verifying both game and mod loader support.
+
 ## Aligning with `src/ContainerTooltips`
 1. **Optional sibling checkout** — If you also maintain the primary mods repository, keep it in a sibling folder so you can compare history. Only source code and translation assets from `src/ContainerTooltips` need to be synchronized here; all project metadata should remain owned by this archive.
 2. **Source of truth** — Treat `src/ContainerTooltips` in the maintained repository as the authoritative codebase for gameplay logic and localization. When updating this archive, copy over the mod's C# source files (excluding the project file) and the `Translations/` assets so the archival package reflects the latest behavior.

--- a/Oni_mods_by_Identifier/ZoomSpeed/ZoomSpeed.csproj
+++ b/Oni_mods_by_Identifier/ZoomSpeed/ZoomSpeed.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net471</TargetFramework>
     <AssemblyName>ZoomSpeed</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>


### PR DESCRIPTION
## Summary
- retarget the ContainerTooltips and ZoomSpeed archival projects to net471
- document the net471 compatibility requirement in the identifier rebuild guide
- record the pending dotnet build verification in NOTES.md

## Testing
- dotnet build Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj /p:Configuration=Release *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e6503ba70c832984c76ad31305d346