### PR TITLE
Expand ILRepack search paths for identifier mods

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -9,6 +9,10 @@
 - Inlined bespoke packaging targets for `ContainerTooltips` and `ZoomSpeed` to merge dependencies, rebuild the Release install folder, and zip the DLL alongside `mod.yaml` and `mod_info.yaml` without importing shared targets from the main solution.
 - Attempted `dotnet build Oni_mods_by_Identifier/ONIMods.sln -c Release` to verify the Release packaging flow, but the container still lacks the `.NET` host (`command not found: dotnet`). Please rebuild locally to confirm the artifacts populate `Release/` and `Distribute/` as expected.
 
+## 2025-12-31 - Identifier ILRepack search path update
+- Expanded the `LibraryPath` passed to ILRepack in `ContainerTooltips` and `ZoomSpeed` so it now probes the build output, the configured `GameFolder`, and the repo-local `lib` directory for Harmony.
+- Attempted to rebuild with `dotnet build Oni_mods_by_Identifier/ONIMods.sln` to confirm ILRepack resolves `0Harmony.dll` without copying it into `bin`, but the container still lacks the `.NET` host (`command not found: dotnet`). Please retry the build locally where the ONI toolchain is available.
+
 ## 2025-12-23 - SuppressNotifications copy tool override scope
 - Widened the override visibility for `CopyEntitySettingsTool`'s drag lifecycle hooks to `public` so they match `DragTool`'s declarations and clear the CS0507 accessibility mismatch.
 - Attempted to rebuild with `dotnet build src/SuppressNotifications/SuppressNotifications.csproj`, but the container still lacks the `.NET` host (`command not found: dotnet`). Please rerun the build locally once the ONI toolchain is available to confirm the access modifier adjustments compile without warnings.

--- a/Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj
+++ b/Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj
@@ -88,7 +88,7 @@
       Parallel="true"
       DebugInfo="true"
       InputAssemblies="@(MergeAssemblies)"
-      LibraryPath="$(TargetDir)"
+      LibraryPath="$(TargetDir);$(GameFolder);$(MSBuildThisFileDirectory)..\\lib\\"
       TargetKind="SameAsPrimaryAssembly"
       OutputFile="$(MergedAssemblyPath)" />
 

--- a/Oni_mods_by_Identifier/ZoomSpeed/ZoomSpeed.csproj
+++ b/Oni_mods_by_Identifier/ZoomSpeed/ZoomSpeed.csproj
@@ -89,7 +89,7 @@
       Parallel="true"
       DebugInfo="true"
       InputAssemblies="@(MergeAssemblies)"
-      LibraryPath="$(TargetDir)"
+      LibraryPath="$(TargetDir);$(GameFolder);$(MSBuildThisFileDirectory)..\\lib\\"
       TargetKind="SameAsPrimaryAssembly"
       OutputFile="$(MergedAssemblyPath)" />
 


### PR DESCRIPTION
## Summary
- extend the ILRepack library search path for ContainerTooltips and ZoomSpeed to include the game folder and repo lib fallback
- document the change and the blocked rebuild attempt in NOTES.md

## Testing
- ❌ `dotnet build Oni_mods_by_Identifier/ONIMods.sln` *(fails: command not found: dotnet in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e656db7e84832995f11d64b6c2124c