### PR TITLE
Trim helper assemblies from identifier outputs

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -508,3 +508,7 @@ lternate language locally to confirm the fallback strings resolve correctly.
 ## 2026-01-02 - Identifier TFMs pinned to net471
 - Downgraded the `ContainerTooltips` and `ZoomSpeed` archival projects to target `net471` so their merged assemblies match ONI's Harmony runtime.
 - Attempted `dotnet build Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj /p:Configuration=Release` to confirm the net471 build and ILRepack packaging, but the container still lacks the `.NET` host (`command not found: dotnet`). Please rebuild locally (Debug/Release) to verify the merged assembly and release zip succeed under the new TFM.
+
+## 2026-01-03 - Identifier post-merge trimming guard
+- Added a `TrimReferenceCopies` MSBuild target to the legacy `ContainerTooltips` and `ZoomSpeed` projects so copy-local references, PLib helpers, and ILRepack staging folders are removed after the merged assembly is produced.
+- Tried `dotnet build Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj /p:Configuration=Release` to validate Debug/Release workflows, but the container still lacks the `.NET` host (`command not found: dotnet`). Please rebuild locally to confirm the merged outputs remain intact while the helper DLLs are trimmed from `$(TargetDir)` and the Release zip.

--- a/Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj
+++ b/Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj
@@ -96,6 +96,25 @@
     <Move SourceFiles="$(MergedPdbPath)" DestinationFiles="$(TargetDir)$(TargetName).pdb" Condition="Exists('$(MergedPdbPath)')" OverwriteReadOnlyFiles="true" />
   </Target>
 
+  <Target Name="TrimReferenceCopies"
+          AfterTargets="MergeDependencies"
+          BeforeTargets="CopyReleaseArtifacts"
+          Condition="Exists('$(TargetDir)')">
+    <ItemGroup>
+      <TrimFiles Include="@(ReferenceCopyLocalPaths)" Condition="Exists('%(Identity)')" />
+      <TrimFiles Include="$(TargetDir)PLib.dll" Condition="Exists('$(TargetDir)PLib.dll')" />
+      <TrimFiles Include="$(TargetDir)PLib.pdb" Condition="Exists('$(TargetDir)PLib.pdb')" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <TrimDirectories Include="$(TargetDir)Merged" Condition="Exists('$(TargetDir)Merged')" />
+      <TrimDirectories Include="$(TargetDir)ILRepack" Condition="Exists('$(TargetDir)ILRepack')" />
+    </ItemGroup>
+
+    <Delete Files="@(TrimFiles)" />
+    <RemoveDir Directories="@(TrimDirectories)" />
+  </Target>
+
   <Target Name="PrepareReleaseFolders" AfterTargets="MergeDependencies" Condition="'$(Configuration)' == 'Release' And '$(ShouldDistribute)' != 'false'">
     <MakeDir Directories="$(DistributeFolder)" />
   </Target>

--- a/Oni_mods_by_Identifier/ZoomSpeed/ZoomSpeed.csproj
+++ b/Oni_mods_by_Identifier/ZoomSpeed/ZoomSpeed.csproj
@@ -97,6 +97,25 @@
     <Move SourceFiles="$(MergedPdbPath)" DestinationFiles="$(TargetDir)$(TargetName).pdb" Condition="Exists('$(MergedPdbPath)')" OverwriteReadOnlyFiles="true" />
   </Target>
 
+  <Target Name="TrimReferenceCopies"
+          AfterTargets="MergeDependencies"
+          BeforeTargets="CopyReleaseArtifacts"
+          Condition="Exists('$(TargetDir)')">
+    <ItemGroup>
+      <TrimFiles Include="@(ReferenceCopyLocalPaths)" Condition="Exists('%(Identity)')" />
+      <TrimFiles Include="$(TargetDir)PLib.dll" Condition="Exists('$(TargetDir)PLib.dll')" />
+      <TrimFiles Include="$(TargetDir)PLib.pdb" Condition="Exists('$(TargetDir)PLib.pdb')" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <TrimDirectories Include="$(TargetDir)Merged" Condition="Exists('$(TargetDir)Merged')" />
+      <TrimDirectories Include="$(TargetDir)ILRepack" Condition="Exists('$(TargetDir)ILRepack')" />
+    </ItemGroup>
+
+    <Delete Files="@(TrimFiles)" />
+    <RemoveDir Directories="@(TrimDirectories)" />
+  </Target>
+
   <Target Name="PrepareReleaseFolders" AfterTargets="MergeDependencies" Condition="'$(Configuration)' == 'Release' And '$(ShouldDistribute)' != 'false'">
     <MakeDir Directories="$(DistributeFolder)" />
   </Target>


### PR DESCRIPTION
## Summary
- add a TrimReferenceCopies MSBuild target to the legacy ContainerTooltips and ZoomSpeed projects so copy-local dependencies and ILRepack staging folders are removed after merging
- document the change and the missing dotnet host limitation in NOTES.md

## Testing
- dotnet build Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj -c Release *(fails: `dotnet` is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e6592b3e148329bc9e15817d0156bd