### PR TITLE
Restrict identifier trim targets to merged output

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -13,6 +13,10 @@
 - Expanded the `LibraryPath` passed to ILRepack in `ContainerTooltips` and `ZoomSpeed` so it now probes the build output, the configured `GameFolder`, and the repo-local `lib` directory for Harmony.
 - Attempted to rebuild with `dotnet build Oni_mods_by_Identifier/ONIMods.sln` to confirm ILRepack resolves `0Harmony.dll` without copying it into `bin`, but the container still lacks the `.NET` host (`command not found: dotnet`). Please retry the build locally where the ONI toolchain is available.
 
+## 2026-01-07 - Identifier release trim safety net
+- Limited the `TrimReferenceCopies` target in `ContainerTooltips` and `ZoomSpeed` to operate only on files inside `$(TargetDir)` by projecting `@(ReferenceCopyLocalPaths)` onto local filenames and skipping the merged DLL/PDB pair.
+- The cleanup still removes `Merged`/`ILRepack` scratch directories before `CopyReleaseArtifacts`, but the container cannot validate the flow because `dotnet` is unavailable (`command not found: dotnet`). Please rebuild both projects locally in Release to ensure only the merged assembly, its PDB, and YAML assets remain before zipping.
+
 ## 2025-12-23 - SuppressNotifications copy tool override scope
 - Widened the override visibility for `CopyEntitySettingsTool`'s drag lifecycle hooks to `public` so they match `DragTool`'s declarations and clear the CS0507 accessibility mismatch.
 - Attempted to rebuild with `dotnet build src/SuppressNotifications/SuppressNotifications.csproj`, but the container still lacks the `.NET` host (`command not found: dotnet`). Please rerun the build locally once the ONI toolchain is available to confirm the access modifier adjustments compile without warnings.

--- a/Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj
+++ b/Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj
@@ -101,9 +101,8 @@
           BeforeTargets="CopyReleaseArtifacts"
           Condition="Exists('$(TargetDir)')">
     <ItemGroup>
-      <TrimFiles Include="@(ReferenceCopyLocalPaths)" Condition="Exists('%(Identity)')" />
-      <TrimFiles Include="$(TargetDir)PLib.dll" Condition="Exists('$(TargetDir)PLib.dll')" />
-      <TrimFiles Include="$(TargetDir)PLib.pdb" Condition="Exists('$(TargetDir)PLib.pdb')" />
+      <TrimFiles Include="@(ReferenceCopyLocalPaths->'$(TargetDir)%(Filename)%(Extension)')"
+                 Condition="Exists('%(TrimFiles.Identity)') and '%(TrimFiles.Identity)' != '$(TargetPath)' and '%(TrimFiles.Identity)' != '$(TargetDir)$(TargetName).pdb'" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Oni_mods_by_Identifier/ZoomSpeed/ZoomSpeed.csproj
+++ b/Oni_mods_by_Identifier/ZoomSpeed/ZoomSpeed.csproj
@@ -102,9 +102,8 @@
           BeforeTargets="CopyReleaseArtifacts"
           Condition="Exists('$(TargetDir)')">
     <ItemGroup>
-      <TrimFiles Include="@(ReferenceCopyLocalPaths)" Condition="Exists('%(Identity)')" />
-      <TrimFiles Include="$(TargetDir)PLib.dll" Condition="Exists('$(TargetDir)PLib.dll')" />
-      <TrimFiles Include="$(TargetDir)PLib.pdb" Condition="Exists('$(TargetDir)PLib.pdb')" />
+      <TrimFiles Include="@(ReferenceCopyLocalPaths->'$(TargetDir)%(Filename)%(Extension)')"
+                 Condition="Exists('%(TrimFiles.Identity)') and '%(TrimFiles.Identity)' != '$(TargetPath)' and '%(TrimFiles.Identity)' != '$(TargetDir)$(TargetName).pdb'" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary
- scope ContainerTooltips and ZoomSpeed reference trimming to local build output so only the merged DLL/PDB remain
- retain cleanup of temporary Merged/ILRepack directories ahead of CopyReleaseArtifacts
- document the missing dotnet runtime that blocks verifying the Release build flow in this container

## Testing
- dotnet build Oni_mods_by_Identifier/ContainerTooltips/ContainerTooltips.csproj -c Release *(fails: command not found: dotnet)*
- dotnet build Oni_mods_by_Identifier/ZoomSpeed/ZoomSpeed.csproj -c Release *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68e65ee0e12083299a73461dd7a80381